### PR TITLE
[10.0][FIX] Fix little issue if no '__doc__' filled

### DIFF
--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -282,7 +282,7 @@ class BaseRestService(AbstractComponent):
             parameters = self._get_openapi_default_parameters()
             responses = self._get_openapi_default_responses().copy()
             path_info = {
-                'summary': textwrap.dedent(method.__doc__),
+                'summary': textwrap.dedent(method.__doc__ or ''),
                 'parameters': parameters,
                 'responses': responses,
             }


### PR DESCRIPTION
**Issue**
If no `__doc__` filled on the target method, an exception is raised

**Fix**
Just add an empty text when no `__doc__` on the function.