### PR TITLE
[10.0][IMP][FIX] Validator in case of inherit

### DIFF
--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -297,6 +297,12 @@ class BaseRestService(AbstractComponent):
                     }
                 })
             input_schema = self._get_input_schema(name)
+            # If we don't have an input schema (None), we have to considerate
+            # the function as private.
+            # Useful in case of inheritance of Components with
+            # functions without leading "_".
+            if not isinstance(input_schema, dict):
+                continue
             output_schema = self._get_output_schema(name)
             json_input_schema = cerberus_to_json(
                 input_schema)


### PR DESCRIPTION
**Current behaviour:**
A Component with a public method (without leading `_`) without validator should be considerate as private.
Because in case of inherit of Components with public methods, they'll be exposed/visible to the service. And as they don't have any validator, they shouldn't be displayed (swagger).

**Why a fix?**
Because in case of inherit (with public method without validators), the swagger interface is broken.

**Example**
```
class ComponentA(Component):
    _name = "comp.a"

    def get_uncrypted_pwd_current_user():
        return self.env.user.password

class ComponentB(Component):
    _name = "comp.b"
    _inherit = ["comp.a"]

    def get_user_name(id):
        return self.env['res.users'].browse(id).name

    def _validator_get_user_name():
        return ...
```
The `get_uncrypted_pwd_current_user()` is visible into swagger.