### PR TITLE
[13.0][FIX] Usage mention correct /api-docs discovery URL

### DIFF
--- a/base_rest_demo/readme/USAGE.rst
+++ b/base_rest_demo/readme/USAGE.rst
@@ -1,4 +1,4 @@
 This module provides sample REST services based on base_rest. The documentation
-of provided services is available at the '/api_docs' URL. This frontend based
+of provided services is available at the ``/api-docs`` URL. This frontend based
 on `Swagger <https://swagger.io/>`_ is generated from the implemented
 webservices.


### PR DESCRIPTION
forward port of #61 