### PR TITLE
[12.0] graphql_base: Add aliases and handle 2one relations better

### DIFF
--- a/graphql_base/__init__.py
+++ b/graphql_base/__init__.py
@@ -2,4 +2,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from .controllers import GraphQLControllerMixin
-from .types import OdooObjectType
+from .types import alias, OdooObjectType

--- a/graphql_base/types.py
+++ b/graphql_base/types.py
@@ -72,8 +72,7 @@ def alias(target_name):
     @classmethod
     def resolve_field(cls, root, info):
         resolver = (
-            cls._meta.default_resolver
-            or graphene.types.resolver.get_default_resolver()
+            cls._meta.default_resolver or graphene.types.resolver.get_default_resolver()
         )
         field = cls._meta.fields.get(info.field_name, None)
         default_value = getattr(field, "default_value", None)

--- a/graphql_demo/schema.py
+++ b/graphql_demo/schema.py
@@ -10,7 +10,7 @@ import graphene
 from odoo import _
 from odoo.exceptions import UserError
 
-from odoo.addons.graphql_base import OdooObjectType
+from odoo.addons.graphql_base import alias, OdooObjectType
 
 
 class Country(OdooObjectType):
@@ -30,13 +30,8 @@ class Partner(OdooObjectType):
     is_company = graphene.Boolean(required=True)
     contacts = graphene.List(graphene.NonNull(lambda: Partner), required=True)
 
-    @staticmethod
-    def resolve_country(root, info):
-        return root.country_id or None
-
-    @staticmethod
-    def resolve_contacts(root, info):
-        return root.child_ids
+    resolve_country = alias("country_id")
+    resolve_contacts = alias("child_ids")
 
 
 class Query(graphene.ObjectType):

--- a/graphql_demo/schema.py
+++ b/graphql_demo/schema.py
@@ -10,7 +10,7 @@ import graphene
 from odoo import _
 from odoo.exceptions import UserError
 
-from odoo.addons.graphql_base import alias, OdooObjectType
+from odoo.addons.graphql_base import OdooObjectType, alias
 
 
 class Country(OdooObjectType):

--- a/graphql_demo/tests/test_graphene.py
+++ b/graphql_demo/tests/test_graphene.py
@@ -54,13 +54,9 @@ class TestGraphene(TransactionCase):
             {
                 "name": partner.name,
                 "country": (
-                    {"name": partner.country_id.name}
-                    if partner.country_id
-                    else None
+                    {"name": partner.country_id.name} if partner.country_id else None
                 ),
-                "contacts": [
-                    {"name": contact.name} for contact in partner.child_ids
-                ],
+                "contacts": [{"name": contact.name} for contact in partner.child_ids],
             }
             for partner in self.env["res.partner"].search([])
         ]


### PR DESCRIPTION
I found a few ways to reduce boilerplate when working with `graphql_base`.

When only one record is expected, empty recordsets can be replaced by `None`, so you don't need a custom resolver to handle that.

When you just want to rename a field (e.g. `partner_id` to `partner`) the new `alias()` function can create an appropriate resolver for you. That feels like it could be a feature in `graphene` but I couldn't find anything.