### PR TITLE
[12.0][FIX][base_rest] issue when _description is None

### DIFF
--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -229,7 +229,7 @@ class BaseRestService(AbstractComponent):
     def _get_openapi_info(self):
         return {
             "title": "%s REST services" % self._usage,
-            "description": textwrap.dedent(getattr(self, "_description", "")),
+            "description": textwrap.dedent(self._description or ""),
         }
 
     def _get_openapi_servers(self):


### PR DESCRIPTION
The PR #68 while fixing an issue introduced a bug.

self._description is always defined and can be `None` : 
```py
class BaseRestService(AbstractComponent):
    _name = "base.rest.service"

    _description = None  # description included into the openapi doc
```
