### PR TITLE
[13.0][FIX] http/json error on first json request of new worker

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -20,6 +20,7 @@ from werkzeug.exceptions import (
 )
 from werkzeug.utils import escape
 
+import odoo
 from odoo.exceptions import (
     AccessDenied,
     AccessError,
@@ -202,11 +203,17 @@ ori_get_request = Root.get_request
 
 def get_request(self, httprequest):
     db = httprequest.session.db
-    service_registry = _rest_services_databases.get(db)
-    if service_registry:
-        for root_path in service_registry:
-            if httprequest.path.startswith(root_path):
-                return HttpRestRequest(httprequest)
+    if db:
+        # on the very first request processed by a worker,
+        # registry is not loaded yet
+        # so we enforce its loading here to make sure that
+        # _rest_services_databases is not empty
+        odoo.registry(db)
+        service_registry = _rest_services_databases.get(db)
+        if service_registry:
+            for root_path in service_registry:
+                if httprequest.path.startswith(root_path):
+                    return HttpRestRequest(httprequest)
     return ori_get_request(self, httprequest)
 
 


### PR DESCRIPTION
- If the very first request a new http worker has to process is a `base_rest` request of `application/json` type (e.g. a `POST /base_rest_demo_api/private/partner/create`), you will face this confusing issue: [`Function declared as capable of handling request of type 'http' but called with a request of type 'json'`](https://github.com/odoo/odoo/blob/e220c5a28ecbd160be86b0ce00a7f17bcfaa816e/odoo/http.py#L318)

  - Command to reproduce: `curl -X POST -H "Content-Type: application/json" -H "cookie: session_id=$SID;" http://localhost:8069/base_rest_demo_api/private/partner/create -d '{ "name": "test", "city": "test", "street": "test", "zip": "88888" }'`

  - Full error response:

```
{u'jsonrpc': u'2.0', u'id': None, u'error': {u'message': u'Odoo Server Error', u'code': 200, u'data': {u'name': u'werkzeug.exceptions.BadRequest', u'exception_type': u'internal_error', u'arguments': [], u'context': {}, u'debug': u'Traceback (most recent call last):\n  File "/odoo/odoo/http.py", line 624, in _handle_exception\n    return super(JsonRequest, self)._handle_exception(exception)\n  File "/odoo/odoo/http.py", line 310, in _handle_exception\n    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])\n  File "/odoo/odoo/tools/pycompat.py", line 14, in reraise\n    raise value\n  File "/odoo/odoo/http.py", line 669, in dispatch\n    result = self._call_function(**self.params)\n  File "/odoo/odoo/http.py", line 318, in _call_function\n    raise werkzeug.exceptions.BadRequest(msg % params)\nwerkzeug.exceptions.BadRequest: 400 Bad Request: <function RestControllerType._add_default_methods.<locals>.modify at 0x7f2aacd0e488>, /base_rest_demo_api/private/partner/create: Function declared as capable of handling request of type \'http\' but called with a request of type \'json\'\n', u'message': u"400 Bad Request: <function RestControllerType._add_default_methods.<locals>.modify at 0x7f2aacd0e488>, /base_rest_demo_api/private/partner/create: Function declared as capable of handling request of type 'http' but called with a request of type 'json'"}}}
```

- This happens because on the very first request processed by an http worker, `service_registry` will always be `None` [here](https://github.com/OCA/rest-framework/blob/7bd0637cce70902b291f5bdb10cb070774c90db7/base_rest/http.py#L206)

- That's because the loading of the registry will happen [here](https://github.com/odoo/odoo/blob/e220c5a28ecbd160be86b0ce00a7f17bcfaa816e/odoo/http.py#L1439), *after* `get_request()` will already have been called a few lines before, [here](https://github.com/odoo/odoo/blob/e220c5a28ecbd160be86b0ce00a7f17bcfaa816e/odoo/http.py#L1424)

- The proposed fix is simply to enforce the loading of the registry in the `get_request()`

PS:

- Note that a pre-condition for this use case to work, is also to have `base_rest` (or the module relying on it, such as `base_rest_demo`) among the `server_wide_modules`, for the [override of `get_request()`](https://github.com/OCA/rest-framework/blob/7bd0637cce70902b291f5bdb10cb070774c90db7/base_rest/http.py#L203) to be taken into account before the registry is loaded
