### PR TITLE
[14.0][FIX] base_rest: Allows to scroll in case of overflow into the swagge…

### DIFF
--- a/base_rest/views/openapi_template.xml
+++ b/base_rest/views/openapi_template.xml
@@ -18,7 +18,6 @@
                 </script>
 
                 <t t-call-assets="web.assets_common" t-js="false" />
-                <t t-call-assets="web.assets_frontend" t-js="false" />
                 <t t-call-assets="base_rest.assets_swagger" t-js="false" />
                 <link
                     href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700"


### PR DESCRIPTION
…r ui

Before this change, since the assets_frontend was loaded into the swagger ui the overflow was hidden. It was therfore no more possible to scroll into the swagger UI in case of overflow.
The dependency can be safely removed since it's not used by the swagger UI

fixes #94