### PR TITLE
[13.0] Add handlers to delegate validators

### DIFF
--- a/base_rest/components/__init__.py
+++ b/base_rest/components/__init__.py
@@ -1,1 +1,2 @@
 from . import service
+from . import cerberus_validator

--- a/base_rest/components/cerberus_validator.py
+++ b/base_rest/components/cerberus_validator.py
@@ -14,10 +14,10 @@ class BaseRestCerberusValidator(Component):
             _usage = "cerberus.validator"
             _collection = "mycollection"
 
-            def get_validator_handler(self, service, method_name):
+            def get_validator_handler(self, service, method_name, direction):
                 # customize
 
-            def has_validator_handler(self, service, method_name):
+            def has_validator_handler(self, service, method_name, direction):
                 # customize
 
     """
@@ -26,7 +26,7 @@ class BaseRestCerberusValidator(Component):
     _usage = "cerberus.validator"
     _is_rest_service_component = False  # marker to retrieve REST components
 
-    def get_validator_handler(self, service, method_name):
+    def get_validator_handler(self, service, method_name, direction):
         """Get the validator handler for a method
 
         By default, it returns the method on the current service instance. It
@@ -34,10 +34,12 @@ class BaseRestCerberusValidator(Component):
 
         The returned method will be called without arguments, and is expected
         to return the schema.
+
+        direction is either "input" for request schema or "output" for responses.
         """
         return getattr(service, method_name)
 
-    def has_validator_handler(self, service, method_name):
+    def has_validator_handler(self, service, method_name, direction):
         """Return if the service has a validator handler for a method
 
         By default, it returns True if the the method exists on the service. It
@@ -45,5 +47,7 @@ class BaseRestCerberusValidator(Component):
 
         The returned method will be called without arguments, and is expected
         to return the schema.
+
+        direction is either "input" for request schema or "output" for responses.
         """
         return hasattr(service, method_name)

--- a/base_rest/components/cerberus_validator.py
+++ b/base_rest/components/cerberus_validator.py
@@ -1,0 +1,49 @@
+# Copyright 2021 Camptocamp
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo.addons.component.core import Component
+
+
+class BaseRestCerberusValidator(Component):
+    """Component used to lookup the input/output validator methods
+
+    To modify in your services collection::
+
+        class MyCollectionRestCerberusValidator(Component):
+            _name = "mycollection.rest.cerberus.validator"
+            _inherit = "base.rest.cerberus.validator"
+            _usage = "cerberus.validator"
+            _collection = "mycollection"
+
+            def get_validator_handler(self, service, method_name):
+                # customize
+
+            def has_validator_handler(self, service, method_name):
+                # customize
+
+    """
+
+    _name = "base.rest.cerberus.validator"
+    _usage = "cerberus.validator"
+    _is_rest_service_component = False  # marker to retrieve REST components
+
+    def get_validator_handler(self, service, method_name):
+        """Get the validator handler for a method
+
+        By default, it returns the method on the current service instance. It
+        can be customized to delegate the validators to another component.
+
+        The returned method will be called without arguments, and is expected
+        to return the schema.
+        """
+        return getattr(service, method_name)
+
+    def has_validator_handler(self, service, method_name):
+        """Return if the service has a validator handler for a method
+
+        By default, it returns True if the the method exists on the service. It
+        can be customized to delegate the validators to another component.
+
+        The returned method will be called without arguments, and is expected
+        to return the schema.
+        """
+        return hasattr(service, method_name)

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -237,17 +237,21 @@ class RestApiMethodTransformer(object):
 
         return routes
 
-    def _method_to_input_param(self, method):
-        validator_method_name = "_validator_{}".format(method.__name__)
-        if hasattr(self._service, validator_method_name):
+    def _method_to_param(self, validator_method_name):
+        validator_component = self._service.component(usage="cerberus.validator")
+        if validator_component.has_validator_handler(
+            self._service, validator_method_name
+        ):
             return restapi.CerberusValidator(schema=validator_method_name)
         return None
 
+    def _method_to_input_param(self, method):
+        validator_method_name = "_validator_{}".format(method.__name__)
+        return self._method_to_param(validator_method_name)
+
     def _method_to_output_param(self, method):
         validator_method_name = "_validator_return_{}".format(method.__name__)
-        if hasattr(self._service, validator_method_name):
-            return restapi.CerberusValidator(schema=validator_method_name)
-        return None
+        return self._method_to_param(validator_method_name)
 
 
 class RestApiServiceControllerGenerator(object):

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -237,21 +237,21 @@ class RestApiMethodTransformer(object):
 
         return routes
 
-    def _method_to_param(self, validator_method_name):
+    def _method_to_param(self, validator_method_name, direction):
         validator_component = self._service.component(usage="cerberus.validator")
         if validator_component.has_validator_handler(
-            self._service, validator_method_name
+            self._service, validator_method_name, direction
         ):
             return restapi.CerberusValidator(schema=validator_method_name)
         return None
 
     def _method_to_input_param(self, method):
         validator_method_name = "_validator_{}".format(method.__name__)
-        return self._method_to_param(validator_method_name)
+        return self._method_to_param(validator_method_name, "input")
 
     def _method_to_output_param(self, method):
         validator_method_name = "_validator_return_{}".format(method.__name__)
-        return self._method_to_param(validator_method_name)
+        return self._method_to_param(validator_method_name, "output")
 
 
 class RestApiServiceControllerGenerator(object):

--- a/base_rest/restapi.py
+++ b/base_rest/restapi.py
@@ -169,8 +169,8 @@ class CerberusValidator(RestMethodParam):
     def get_cerberus_validator(self, service):
         schema = self._schema
         if isinstance(self._schema, str):
-            # schema is a method name to call on service to get the schema or
-            schema = getattr(service, self._schema)()
+            validator_component = service.component(usage="cerberus.validator")
+            schema = validator_component.get_validator_handler(service, self._schema)()
         if isinstance(schema, Validator):
             return schema
         if isinstance(schema, dict):

--- a/base_rest/restapi.py
+++ b/base_rest/restapi.py
@@ -117,19 +117,19 @@ class CerberusValidator(RestMethodParam):
         self._is_list = is_list
 
     def from_params(self, service, params):
-        validator = self.get_cerberus_validator(service)
+        validator = self.get_cerberus_validator(service, "input")
         if validator.validate(params):
             return validator.document
         raise UserError(_("BadRequest %s") % validator.errors)
 
     def to_response(self, service, result):
-        validator = self.get_cerberus_validator(service)
+        validator = self.get_cerberus_validator(service, "output")
         if validator.validate(result):
             return validator.document
         raise SystemError(_("Invalid Response %s") % validator.errors)
 
     def to_openapi_query_parameters(self, service):
-        json_schema = self.to_json_schema(service)
+        json_schema = self.to_json_schema(service, "input")
         parameters = []
         for prop, spec in list(json_schema["properties"].items()):
             params = {
@@ -159,24 +159,29 @@ class CerberusValidator(RestMethodParam):
 
     def to_openapi_requestbody(self, service):
         return {
-            "content": {"application/json": {"schema": self.to_json_schema(service)}}
+            "content": {
+                "application/json": {"schema": self.to_json_schema(service, "input")}
+            }
         }
 
     def to_openapi_responses(self, service):
-        json_schema = self.to_json_schema(service)
+        json_schema = self.to_json_schema(service, "output")
         return {"200": {"content": {"application/json": {"schema": json_schema}}}}
 
-    def get_cerberus_validator(self, service):
+    def get_cerberus_validator(self, service, direction):
+        assert direction in ("input", "output")
         schema = self._schema
         if isinstance(self._schema, str):
             validator_component = service.component(usage="cerberus.validator")
-            schema = validator_component.get_validator_handler(service, self._schema)()
+            schema = validator_component.get_validator_handler(
+                service, self._schema, direction
+            )()
         if isinstance(schema, Validator):
             return schema
         if isinstance(schema, dict):
             return Validator(schema, purge_unknown=True)
         raise Exception(_("Unable to get cerberus schema from %s") % self._schema)
 
-    def to_json_schema(self, service):
-        schema = self.get_cerberus_validator(service).schema
+    def to_json_schema(self, service, direction):
+        schema = self.get_cerberus_validator(service, direction).schema
         return cerberus_to_json(schema)

--- a/base_rest/tests/common.py
+++ b/base_rest/tests/common.py
@@ -20,6 +20,7 @@ from odoo.addons.component.tests.common import (
     new_rollbacked_env,
 )
 
+from ..components.cerberus_validator import BaseRestCerberusValidator
 from ..components.service import BaseRestService
 from ..controllers.main import RestController, _PseudoCollection
 from ..core import RestServicesRegistry, _rest_services_databases
@@ -91,8 +92,9 @@ class RestServiceRegistryCase(ComponentRegistryCase):
                 class_or_instance._service_registry
             )
 
-        # register our base component
+        # register our base components
         BaseRestService._build_component(class_or_instance.comp_registry)
+        BaseRestCerberusValidator._build_component(class_or_instance.comp_registry)
 
         # Define a base test controller here to avoid to have this controller
         # registered outside tests

--- a/base_rest/tests/test_cerberus_validator.py
+++ b/base_rest/tests/test_cerberus_validator.py
@@ -277,7 +277,7 @@ class TestCerberusValidator(unittest.TestCase, MetaCase("DummyCase", (object,), 
                 return BaseRestCerberusValidator(unittest.mock.Mock())
 
         v = CerberusValidator(schema="_get_simple_schema")
-        validator = v.get_cerberus_validator(MyService())
+        validator = v.get_cerberus_validator(MyService(), "output")
         self.assertTrue(validator)
         self.assertDictEqual(
             validator.root_schema.schema,
@@ -295,5 +295,34 @@ class TestCerberusValidator(unittest.TestCase, MetaCase("DummyCase", (object,), 
                 return BaseRestCerberusValidator(unittest.mock.Mock())
 
         v = CerberusValidator(schema="_get_simple_schema")
-        validator = v.get_cerberus_validator(MyService())
+        validator = v.get_cerberus_validator(MyService(), "input")
+        self.assertTrue(validator.require_all)
+
+    def test_custom_validator_handler(self):
+        assertEq = self.assertEqual
+
+        class CustomBaseRestCerberusValidator(BaseRestCerberusValidator):
+            def get_validator_handler(self, service, method_name, direction):
+                # In your implementation, this is where you can handle how the
+                # validator is retrieved / computed (dispatch to dedicated
+                # components...).
+                assertEq(service, my_service)
+                assertEq(method_name, "my_endpoint")
+                assertEq(direction, "input")
+                # A callable with no parameter is expected.
+                return lambda: Validator(
+                    {"name": {"type": "string", "required": False}}, require_all=True
+                )
+
+            def has_validator_handler(self, service, method_name, direction):
+                return True
+
+        class MyService(object):
+            def component(self, *args, **kwargs):
+                return CustomBaseRestCerberusValidator(unittest.mock.Mock())
+
+        my_service = MyService()
+
+        v = CerberusValidator(schema="my_endpoint")
+        validator = v.get_cerberus_validator(my_service, "input")
         self.assertTrue(validator.require_all)

--- a/base_rest/tests/test_cerberus_validator.py
+++ b/base_rest/tests/test_cerberus_validator.py
@@ -8,6 +8,7 @@ from cerberus import Validator
 from odoo.exceptions import UserError
 from odoo.tests.common import MetaCase
 
+from ..components.cerberus_validator import BaseRestCerberusValidator
 from ..restapi import CerberusValidator
 
 
@@ -272,6 +273,9 @@ class TestCerberusValidator(unittest.TestCase, MetaCase("DummyCase", (object,), 
             def _get_simple_schema(self):
                 return {"name": {"type": "string", "required": True, "nullable": True}}
 
+            def component(self, *args, **kwargs):
+                return BaseRestCerberusValidator(unittest.mock.Mock())
+
         v = CerberusValidator(schema="_get_simple_schema")
         validator = v.get_cerberus_validator(MyService())
         self.assertTrue(validator)
@@ -286,6 +290,9 @@ class TestCerberusValidator(unittest.TestCase, MetaCase("DummyCase", (object,), 
                 return Validator(
                     {"name": {"type": "string", "required": False}}, require_all=True
                 )
+
+            def component(self, *args, **kwargs):
+                return BaseRestCerberusValidator(unittest.mock.Mock())
 
         v = CerberusValidator(schema="_get_simple_schema")
         validator = v.get_cerberus_validator(MyService())

--- a/base_rest_datamodel/restapi.py
+++ b/base_rest_datamodel/restapi.py
@@ -52,19 +52,23 @@ class Datamodel(restapi.RestMethodParam):
     # and use a reference to the schema into the parameters
     def to_openapi_requestbody(self, service):
         return {
-            "content": {"application/json": {"schema": self.to_json_schema(service)}}
+            "content": {
+                "application/json": {"schema": self.to_json_schema(service, "input")}
+            }
         }
 
     def to_openapi_responses(self, service):
         return {
             "200": {
                 "content": {
-                    "application/json": {"schema": self.to_json_schema(service)}
+                    "application/json": {
+                        "schema": self.to_json_schema(service, "output")
+                    }
                 }
             }
         }
 
-    def to_json_schema(self, service):
+    def to_json_schema(self, service, direction):
         converter = self._get_converter()
         schema = self._get_schema(service)
         return converter.resolve_nested_schema(schema)


### PR DESCRIPTION
CerberusValidator looks for the method name on the service component to
get the schema validators.
Delegate this to a Component, so we can customize the way the validator
for a service is found.

E.g.:

* for each service component, we have 2 additional components: a
  validator for the input schema and another for the output schema
* when looking for the validator, we have to search for the
  corresponding input/output validation component

As implemented in: OCA/wms#137

By delegating this lookup to a base "cerberus.validator" component, we
can override the default behavior for a services collection, by
inheriting the Component.

By default, the behavior does not change.
