### PR TITLE
[BUG] issue with datamodel, recursion limit

### DIFF
--- a/base_rest_demo/tests/__init__.py
+++ b/base_rest_demo/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_controller
 from . import test_openapi
 from . import test_exception
+from . import test_new_api

--- a/base_rest_demo/tests/common.py
+++ b/base_rest_demo/tests/common.py
@@ -5,8 +5,10 @@ import json
 import os
 
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
-from odoo.addons.base_rest.tests.common import BaseRestCase
+from odoo.addons.base_rest.tests.common import BaseRestCase, RegistryMixin
 from odoo.addons.component.core import WorkContext
+from odoo.addons.component.tests.common import SavepointComponentCase
+from odoo.addons.datamodel.tests.common import SavepointDatamodelCase
 
 DATA_DIR = os.path.join(os.path.realpath(os.path.dirname(__file__)), "data")
 
@@ -30,3 +32,16 @@ def get_canonical_json(file_name):
     path = os.path.join(DATA_DIR, file_name)
     with open(path, "r") as f:
         return json.load(f)
+
+
+class NewServiceCommonCase(
+    SavepointComponentCase, SavepointDatamodelCase, RegistryMixin
+):
+    @classmethod
+    def _get_service(cls, service_name):
+        collection = _PseudoCollection("base.rest.demo.new_api.services", cls.env)
+        work = WorkContext(
+            model_name="rest.service.registration",
+            collection=collection,
+        )
+        return work.component(usage=service_name)

--- a/base_rest_demo/tests/test_new_api.py
+++ b/base_rest_demo/tests/test_new_api.py
@@ -1,0 +1,14 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from .common import NewServiceCommonCase
+
+
+class TestPartner(NewServiceCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.service = cls._get_service("partner")
+
+    def test_search(self):
+        self.env["res.partner"].create([{"name": f"P{idx}"} for idx in range(0, 1000)])
+        self.service.dispatch("search")


### PR DESCRIPTION
@lmignon @sbidoul 
It seem that we have a huge issue with datamodel.

If you request a lot of record (around 1000) you will have a limit recursion error.
Also (real case in pre-production) when you call again and again the same api you also have the erreur (the limit is cumulative as the object still exist in the registry).

The error is in Mashmallow lib ...