### PR TITLE
rest_log: fix test usage of MockRequest

### DIFF
--- a/rest_log/tests/common.py
+++ b/rest_log/tests/common.py
@@ -2,6 +2,8 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+import contextlib
+
 from odoo.addons.base_rest import restapi
 from odoo.addons.base_rest.tests.common import SavepointRestServiceRegistryCase
 from odoo.addons.component.core import Component
@@ -48,12 +50,11 @@ class TestDBLoggingBase(SavepointRestServiceRegistryCase):
         LoggedService._build_component(class_or_instance.comp_registry)
         return class_or_instance._get_service_component(class_or_instance, "logmycalls")
 
+    @contextlib.contextmanager
     def _get_mocked_request(self, httprequest=None, extra_headers=None):
-        mocked_request = MockRequest(self.env)
-        # Make sure headers are there, no header in default mocked request :(
-        headers = {"Cookie": "IaMaCookie!", "Api-Key": "I_MUST_STAY_SECRET"}
-        headers.update(extra_headers or {})
-        httprequest = httprequest or {}
-        httprequest["headers"] = headers
-        mocked_request.request["httprequest"] = httprequest
-        return mocked_request
+        with MockRequest(self.env) as mocked_request:
+            mocked_request.httprequest = httprequest or mocked_request.httprequest
+            headers = {"Cookie": "IaMaCookie!", "Api-Key": "I_MUST_STAY_SECRET"}
+            headers.update(extra_headers or {})
+            mocked_request.httprequest.headers = headers
+            yield mocked_request

--- a/rest_log/tests/test_db_logging.py
+++ b/rest_log/tests/test_db_logging.py
@@ -1,8 +1,9 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 # from urllib.parse import urlparse
-# import mock
 import json
+
+import mock
 
 from odoo import exceptions
 from odoo.tools import mute_logger
@@ -70,7 +71,9 @@ class DBLoggingCase(TestDBLoggingBase):
         params = {"some": "value"}
         kw = {"result": {"data": "worked!"}}
         # test full data request only once, other tests will skip this part
-        httprequest = {"url": "https://my.odoo.test/service/endpoint", "method": "POST"}
+        httprequest = mock.Mock(
+            url="https://my.odoo.test/service/endpoint", method="POST"
+        )
         extra_headers = {"KEEP-ME": "FOO"}
         with self._get_mocked_request(
             httprequest=httprequest, extra_headers=extra_headers
@@ -79,8 +82,8 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, params=params, **kw
             )
         expected = {
-            "request_url": httprequest["url"],
-            "request_method": httprequest["method"],
+            "request_url": httprequest.url,
+            "request_method": httprequest.method,
             "state": "success",
             "error": False,
             "exception_name": False,


### PR DESCRIPTION
This commit

https://github.com/odoo/odoo/commit/9a129ca95d80b12f6cf4bf65ff3b7fe4d0ac8cc7

refactored MockRequest which breaks tests.
