### PR TITLE
[13.0][FIX] base_rest invalid dynamic object (controller) construction

### DIFF
--- a/base_rest/controllers/main.py
+++ b/base_rest/controllers/main.py
@@ -36,7 +36,9 @@ class RestControllerType(ControllerType):
             # our RestConrtroller must be a direct child of Controller
             bases += (Controller,)
         super(RestControllerType, cls).__init__(name, bases, attrs)
-        if "RestController" not in globals() or RestController not in bases:
+        if "RestController" not in globals() or not any(
+            issubclass(b, RestController) for b in bases
+        ):
             return
         # register the rest controller into the rest controllers registry
         root_path = getattr(cls, "_root_path", None)


### PR DESCRIPTION
**Info:**
This PR fix 1 errors due to changes on new API:
1. Inheritance between controllers ignored (this PR);
2. `_default_auth` on controllers not applied on routes (I create another PR because it could be an expected behavior; lets discussion open: https://github.com/OCA/rest-framework/pull/130).

https://github.com/OCA/rest-framework/pull/48
So this bug in also in `12.0`, `13.0` and `14.0`.

**TODO:**
1. Unit test

### 1 - Controllers inheritance
**Bug - How to reproduce:**
Inherit an existing controller (to have a real case, I'm using as example the `shopinvader_locomotive` module who has a controller who uses `RestController`).
Try to overwrite a function (`_get_component_context(...)` for my example).
Currently if you put a break-point in `_get_component_context(...)` it's not loaded at all. As the controller is not really loaded (that's the issue).

```
from odoo.addons.shopinvader.controllers.main import InvaderController
from odoo.http import request


class LocomotiveInvaderController(InvaderController):
    @classmethod
    def _get_client_header(cls, headers):
        res = {}
        for key, val in headers.items():
            if key.upper().startswith("HTTP_INVADER_CLIENT_"):
                res[key.replace("HTTP_INVADER_CLIENT_", "")] = val
        return res

    def _get_component_context(self):
        res = super()._get_component_context()
        headers = request.httprequest.environ
        res["client_header"] = self._get_client_header(headers)
        return res
```

**Why the controller is not loaded?**
When Odoo starts, the following line checks if the `Controller` (`LocomotiveInvaderController`) that we're trying to load is a `RestController` (quite logic, the purpose is to load specific controllers for Rest only).
But as the `LocomotiveInvaderController` inherit the `InvaderController`, the `RestController` is not (directly) into the `bases`. So it's ignored.
https://github.com/acsone/rest-framework/blob/e572040ec41383d07a106742ceb185f274203391/base_rest/controllers/main.py#L39
But in this case, we don't want to inherit `RestController` because we want to inherit the existing behavior of the `InvaderController`.
So the line referenced just before should check if at least one "super-type" is a `RestController` to know if it must be considered as a Rest controller or not.

**Additionnal note:**
As there is a `metaclass` specified on `RestController`, it's not possible to use the `isinstance(...)` who'll return this `metaclass` (`RestControllerType`) and we need to have `RestController`.