### PR TITLE
[12.0][FIX] base_rest: Allow disabling a service when _is_rest_service_component is False

### DIFF
--- a/base_rest/controllers/api_docs.py
+++ b/base_rest/controllers/api_docs.py
@@ -62,7 +62,7 @@ class ApiDocsController(Controller):
     def _filter_service_components(self, components):
         r = []
         for c in components:
-            if hasattr(c, "_is_rest_service_component") and c._usage:
+            if getattr(c, "_is_rest_service_component", None) and c._usage:
                 r.append(c)
         return r
 


### PR DESCRIPTION
Currently, only the presence of the attribute is inspected, which means

  _is_rest_service_component = False

Has the same effect as:

  _is_rest_service_component = True