### PR TITLE
[13.0][FIX] base_rest: fix default_auth not automatically applied on routes

### DIFF
--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -29,6 +29,9 @@ from ..core import (
 )
 from ..tools import _inspect_methods
 
+# Decorator attribute added on a route function (cfr Odoo's route)
+ROUTING_DECORATOR_ATTR = "routing"
+
 
 class RestServiceRegistation(models.AbstractModel):
     """Register REST services into the REST services registry
@@ -160,10 +163,31 @@ class RestApiMethodTransformer(object):
         for name, method in _inspect_methods(self._service.__class__):
             if not self._is_public_api_method(name):
                 continue
-            if not hasattr(method, "routing"):
+            if not hasattr(method, ROUTING_DECORATOR_ATTR):
                 methods_to_fix.append(method)
         for method in methods_to_fix:
             self._fix_method_decorator(method)
+        self._update_auth_method_controller()
+
+    def _update_auth_method_controller(self):
+        """
+        Set the automatic auth on controller's routes.
+
+        During definition of new controller, the _default_auth should be
+        applied on every routes (cfr @route odoo's decorator).
+        This auth attribute should be applied only if the route doesn't already
+        define it.
+        :return:
+        """
+        # If the controller class doesn't have the _default_auth, we don't
+        # have to define it on every routes.
+        if not hasattr(self._controller_class, "_default_auth"):
+            return
+        for _name, method in _inspect_methods(self._controller_class):
+            controller_default_auth = {"auth": self._controller_class._default_auth}
+            routing = getattr(method, ROUTING_DECORATOR_ATTR, controller_default_auth)
+            if "auth" not in routing:
+                routing.update(controller_default_auth)
 
     def _is_public_api_method(self, method_name):
         if method_name.startswith("_"):

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -95,6 +95,27 @@ class RestServiceRegistation(models.AbstractModel):
         # register our conroller into the list of available controllers
         name_class = ("{}.{}".format(ctrl_cls.__module__, ctrl_cls.__name__), ctrl_cls)
         http.controllers_per_module[addon_name].append(name_class)
+        self._update_auth_method_controller(controller_class=ctrl_cls)
+
+    def _update_auth_method_controller(self, controller_class):
+        """
+        Set the automatic auth on controller's routes.
+
+        During definition of new controller, the _default_auth should be
+        applied on every routes (cfr @route odoo's decorator).
+        This auth attribute should be applied only if the route doesn't already
+        define it.
+        :return:
+        """
+        # If the controller class doesn't have the _default_auth, we don't
+        # have to define it on every routes.
+        if not hasattr(controller_class, "_default_auth"):
+            return
+        controller_default_auth = {"auth": controller_class._default_auth}
+        for _name, method in _inspect_methods(controller_class):
+            routing = getattr(method, ROUTING_DECORATOR_ATTR, None)
+            if routing is not None and not routing.get("auth"):
+                routing.update(controller_default_auth)
 
     def _get_services(self, collection_name):
         collection = _PseudoCollection(collection_name, self.env)
@@ -167,27 +188,6 @@ class RestApiMethodTransformer(object):
                 methods_to_fix.append(method)
         for method in methods_to_fix:
             self._fix_method_decorator(method)
-        self._update_auth_method_controller()
-
-    def _update_auth_method_controller(self):
-        """
-        Set the automatic auth on controller's routes.
-
-        During definition of new controller, the _default_auth should be
-        applied on every routes (cfr @route odoo's decorator).
-        This auth attribute should be applied only if the route doesn't already
-        define it.
-        :return:
-        """
-        # If the controller class doesn't have the _default_auth, we don't
-        # have to define it on every routes.
-        if not hasattr(self._controller_class, "_default_auth"):
-            return
-        for _name, method in _inspect_methods(self._controller_class):
-            controller_default_auth = {"auth": self._controller_class._default_auth}
-            routing = getattr(method, ROUTING_DECORATOR_ATTR, controller_default_auth)
-            if "auth" not in routing:
-                routing.update(controller_default_auth)
 
     def _is_public_api_method(self, method_name):
         if method_name.startswith("_"):

--- a/base_rest/tests/common.py
+++ b/base_rest/tests/common.py
@@ -103,7 +103,24 @@ class RestServiceRegistryCase(ComponentRegistryCase):
             _collection_name = class_or_instance._collection_name
             _default_auth = "public"
 
+            @http.route("/my_controller_route_without_auth")
+            def my_controller_route_without_auth(self):
+                return {}
+
+            @http.route("/my_controller_route_with_auth_public", auth="public")
+            def my_controller_route_with_auth_public(self):
+                return {}
+
+            @http.route("/my_controller_route_without_auth_2", auth=None)
+            def my_controller_route_without_auth_2(self):
+                return {}
+
         class_or_instance._BaseTestController = BaseTestController
+        class_or_instance._controller_route_method_names = {
+            "my_controller_route_without_auth",
+            "my_controller_route_with_auth_public",
+            "my_controller_route_without_auth_2",
+        }
 
     @staticmethod
     def _teardown_registry(class_or_instance):

--- a/base_rest/tests/test_controller_builder.py
+++ b/base_rest/tests/test_controller_builder.py
@@ -90,7 +90,8 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "delete_delete",
                 "post_my_method",
                 "post_my_instance_method",
-            },
+            }
+            | self._controller_route_method_names,
         )
         self.assertTrue(controller)
         # the generated method_name is always the {http_method}_{method_name}
@@ -257,7 +258,9 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
 
         routes = self._get_controller_route_methods(controller)
         self.assertSetEqual(
-            set(routes.keys()), {"get_get", "get_get_name", "post_update_name"}
+            set(routes.keys()),
+            {"get_get", "get_get_name", "post_update_name"}
+            | self._controller_route_method_names,
         )
 
         method = routes["get_get"]
@@ -346,7 +349,9 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
 
         routes = self._get_controller_route_methods(controller)
         self.assertSetEqual(
-            set(routes.keys()), {"get_get", "get_get_name", "post_update_name"}
+            set(routes.keys()),
+            {"get_get", "get_get_name", "post_update_name"}
+            | self._controller_route_method_names,
         )
 
         method = routes["get_get"]
@@ -386,4 +391,81 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "csrf": False,
                 "routes": ["/test_controller/partner/<int:id>/change_name"],
             },
+        )
+
+
+class TestControllerBuilder2(TransactionRestServiceRegistryCase):
+    """Test Odoo controller builder
+
+    In this class we test the generation of odoo controllers from the services
+    component
+
+    The test requires a fresh base crontroller
+    """
+
+    def test_04(self):
+        """Test controller generated from services with new API methods and
+        old api takes into account the _default_auth
+        Routes directly defined on the RestConroller without auth should also
+        use the _default_auth
+        """
+        default_auth = "my_default_auth"
+        self._BaseTestController._default_auth = default_auth
+
+        # pylint: disable=R7980
+        class TestService(Component):
+            _inherit = "base.rest.service"
+            _name = "test.partner.service"
+            _usage = "partner"
+            _collection = self._collection_name
+            _description = "test"
+
+            @restapi.method([(["/new_api_method_with_auth"], "GET")], auth="public")
+            def new_api_method_with_auth(self, _id):
+                return {"name": self.env["res.partner"].browse(_id).name}
+
+            @restapi.method([(["/new_api_method_without_auth"], "GET")])
+            def new_api_method_without_auth(self, _id):
+                return {"name": self.env["res.partner"].browse(_id).name}
+
+            # OLD API method withour auth
+            def get(self, _id, message):
+                pass
+
+            # Validator
+            def _validator_get(self):
+                # no parameters by default
+                return {}
+
+        self._build_services(self, TestService)
+        controller = self._get_controller_for(TestService)
+
+        routes = self._get_controller_route_methods(controller)
+        self.assertEqual(
+            routes["get_new_api_method_with_auth"].routing["auth"],
+            "public",
+            "wrong auth for get_new_api_method_with_auth",
+        )
+        self.assertEqual(
+            routes["get_new_api_method_without_auth"].routing["auth"],
+            default_auth,
+            "wrong auth for get_new_api_method_without_auth",
+        )
+        self.assertEqual(
+            routes["get_get"].routing["auth"], default_auth, "wrong auth for get_get"
+        )
+        self.assertEqual(
+            routes["my_controller_route_without_auth"].routing["auth"],
+            default_auth,
+            "wrong auth for my_controller_route_without_auth",
+        )
+        self.assertEqual(
+            routes["my_controller_route_with_auth_public"].routing["auth"],
+            "public",
+            "wrong auth for my_controller_route_with_auth_public",
+        )
+        self.assertEqual(
+            routes["my_controller_route_without_auth_2"].routing["auth"],
+            default_auth,
+            "wrong auth for my_controller_route_without_auth_2",
         )


### PR DESCRIPTION
Issue/regression (IMO) caused by New API: https://github.com/OCA/rest-framework/pull/48.
Previously, this fix was integrated into https://github.com/OCA/rest-framework/pull/126.

This bug (if it is) in also in `12.0`, `13.0` and `14.0`.

**TODO:**
1. Unit test

Previously (before changes to new API), `auth` on routes were automatically applied based on the `_default_auth` defined on the controller.

As the code has been removed due to new implementation, I add a new function to automatically apply this attribute.
Only if the route doesn't specify manually the `auth` attribute (who should still possible).