### PR TITLE
[12.0] [FIX] base_rest: do not crash on missing description

### DIFF
--- a/base_rest/apispec/base_rest_service_apispec.py
+++ b/base_rest/apispec/base_rest_service_apispec.py
@@ -24,7 +24,7 @@ class BaseRestServiceAPISpec(APISpec):
             openapi_version="3.0.0",
             info={
                 "description": textwrap.dedent(
-                    getattr(self._service, "_description", "")
+                    getattr(self._service, "_description", "") or ""
                 )
             },
             servers=self._get_servers(),


### PR DESCRIPTION
In fact, there is _description = None in _name = "base.rest.service", so any service that does not have a description crashes.
It's a remake of #72
Forward/backports to be done again in all branches where the bug was reintroduced I guess.
