### PR TITLE
[13.0] rest_log misc improvements

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -52,6 +52,8 @@ class JSONEncoder(json.JSONEncoder):
             return obj.isoformat()
         elif isinstance(obj, decimal.Decimal):
             return float(obj)
+        elif isinstance(obj, set):
+            return tuple(obj)
         return super(JSONEncoder, self).default(obj)
 
 

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -11,6 +11,7 @@ from werkzeug.urls import url_encode, url_join
 from odoo import exceptions, registry
 from odoo.http import request
 
+from odoo.addons.base_rest.http import JSONEncoder
 from odoo.addons.component.core import AbstractComponent
 
 from ..exceptions import (
@@ -18,6 +19,11 @@ from ..exceptions import (
     RESTServiceUserErrorException,
     RESTServiceValidationErrorException,
 )
+
+
+def json_dump(data):
+    """Encode data to JSON as we like."""
+    return json.dumps(data, cls=JSONEncoder, indent=4, sort_keys=True)
 
 
 class BaseRESTService(AbstractComponent):
@@ -118,9 +124,9 @@ class BaseRESTService(AbstractComponent):
             "collection": self._collection,
             "request_url": httprequest.url,
             "request_method": httprequest.method,
-            "params": json.dumps(params, indent=4, sort_keys=True),
-            "headers": json.dumps(headers, indent=4, sort_keys=True),
-            "result": json.dumps(result, indent=4, sort_keys=True),
+            "params": json_dump(params),
+            "headers": json_dump(headers),
+            "result": json_dump(result),
             "error": error,
             "exception_name": exception_name,
             "exception_message": exception_message,

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -115,6 +115,7 @@ class BaseRESTService(AbstractComponent):
                 exception_name = orig_exception.__module__ + "." + exception_name
             exception_message = self._get_exception_message(orig_exception)
         return {
+            "collection": self._collection,
             "request_url": httprequest.url,
             "request_method": httprequest.method,
             "params": json.dumps(params, indent=4, sort_keys=True),

--- a/rest_log/models/rest_log.py
+++ b/rest_log/models/rest_log.py
@@ -25,6 +25,7 @@ class RESTLog(models.Model):
         "UnboundLocalError": "severe",
     }
 
+    collection = fields.Char(index=True)
     request_url = fields.Char(readonly=True, string="Request URL")
     request_method = fields.Char(readonly=True)
     params = fields.Text(readonly=True)

--- a/rest_log/models/rest_log.py
+++ b/rest_log/models/rest_log.py
@@ -128,3 +128,52 @@ class RESTLog(models.Model):
         if logs:
             logs.unlink()
         return True
+
+    def _get_log_active_param(self):
+        param = self.env["ir.config_parameter"].sudo().get_param("rest.log.active")
+        return param.strip() if param else ""
+
+    @tools.ormcache("self._get_log_active_param()")
+    def _get_log_active_conf(self):
+        """Compute log active configuration.
+
+        Possible configuration contains a CSV like this:
+
+            `collection_name` -> enable for all endpoints of the collection
+            `collection_name.usage` -> enable for specific endpoints
+            `collection_name.usage.endpoint` -> enable for specific endpoints
+            `collection_name*:state` -> enable only for specific state (success, failed)
+
+        By default matching keys are enabled for all states.
+
+        :return: mapping by matching key / enabled states
+        """
+        param = self._get_log_active_param()
+        conf = {}
+        lines = [x.strip() for x in param.split(",") if x.strip()]
+        for line in lines:
+            bits = [x.strip() for x in line.split(":") if x.strip()]
+            if len(bits) > 1:
+                match_key = bits[0]
+                # fmt: off
+                states = (bits[1], )
+                # fmt: on
+            else:
+                match_key = line
+                states = ("success", "failed")
+            conf[match_key] = states
+        return conf
+
+    @api.model
+    def _get_matching_active_conf(self, collection, usage, method_name):
+        """Retrieve conf matching current service and method.
+        """
+        conf = self._get_log_active_conf()
+        candidates = (
+            collection + "." + usage + "." + method_name,
+            collection + "." + usage,
+            collection,
+        )
+        for candidate in candidates:
+            if conf.get(candidate):
+                return conf.get(candidate)

--- a/rest_log/readme/CONFIGURE.rst
+++ b/rest_log/readme/CONFIGURE.rst
@@ -13,3 +13,21 @@ You can change the duration of the retention by changing the System Parameter
 If the value is set to 0, the logs are not stored at all.
 
 Logged data is: request URL and method, parameters, headers, result or error.
+
+
+Logs activation
+~~~~~~~~~~~~~~~
+
+You have 2 ways to activate logging:
+
+* on the service component set `_log_calls_in_db = True`
+* via configuration
+
+In the 1st case, calls will be always be logged.
+
+In the 2nd case you can set ``rest.log.active`` param as::
+
+    `collection_name`  # enable for all endpoints of the collection
+    `collection_name.usage`  # enable for specific endpoints
+    `collection_name.usage.endpoint`  # enable for specific endpoints
+    `collection_name*:state`  # enable only for specific state (success, failed)

--- a/rest_log/tests/test_db_logging.py
+++ b/rest_log/tests/test_db_logging.py
@@ -105,6 +105,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "request_url": httprequest.url,
             "request_method": httprequest.method,
             "state": "success",
@@ -134,6 +135,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "state": "failed",
             "result": "{}",
             "error": False,
@@ -157,6 +159,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "state": "failed",
             "result": "{}",
             "error": fake_tb,
@@ -184,6 +187,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "state": "failed",
             "result": "{}",
             "error": fake_tb,

--- a/rest_log/views/rest_log_views.xml
+++ b/rest_log/views/rest_log_views.xml
@@ -5,6 +5,7 @@
         <field name="model">rest.log</field>
         <field name="arch" type="xml">
             <tree decoration-danger="state == 'failed'">
+                <field name="collection" optional="hide" />
                 <field name="create_uid" />
                 <field name="create_date" />
                 <field name="request_method" />
@@ -27,6 +28,7 @@
                 <sheet>
                     <group>
                         <group>
+                            <field name="collection" />
                             <field name="request_url" />
                             <field name="request_method" />
                         </group>
@@ -76,6 +78,7 @@
         <field name="model">rest.log</field>
         <field name="arch" type="xml">
             <search>
+                <field name="collection" />
                 <field name="state" />
                 <field name="request_url" />
                 <field name="request_method" />
@@ -111,6 +114,12 @@
                     domain="[('severity', '=', 'functional')]"
                 />
                 <group expand="0" string="Group By">
+                    <filter
+                        string="Collection"
+                        name="by_collection"
+                        domain="[]"
+                        context="{'group_by': 'collection'}"
+                    />
                     <filter
                         string="User"
                         name="by_user"


### PR DESCRIPTION
See atomic commits for details.

Most important change: you can now selectively enable logging by:

- `collection_name`  # enable for all endpoints of the collection
- `collection_name.usage`  # enable for specific endpoints
- `collection_name.usage.endpoint`  # enable for specific endpoints
- `collection_name*:state`  # enable only for specific state (success, failed)
