### PR TITLE
[IMP] base_rest: Allow to pass the url parameters as kwargs

### DIFF
--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -134,7 +134,7 @@ class BaseRestService(AbstractComponent):
             return result
         return output_param.to_response(self, result)
 
-    def dispatch(self, method_name, *args, params=None):
+    def dispatch(self, method_name, *args, params=None, **kwargs):
         """
         This method dispatch the call to the final method.
         Before the call parameters are processed by the
@@ -155,9 +155,11 @@ class BaseRestService(AbstractComponent):
         if isinstance(secure_params, dict):
             # for backward compatibility methods expecting json params
             # are declared as m(self, p1=None, p2=None) or m(self, **params)
-            res = method(*args, **secure_params)
+            final_params = kwargs.copy()
+            final_params.update(secure_params)
+            res = method(*args, **final_params)
         else:
-            res = method(*args, secure_params)
+            res = method(*args, secure_params, **kwargs)
         self._log_call(method, params, secure_params, res)
         return self._prepare_response(method, res)
 

--- a/base_rest/controllers/main.py
+++ b/base_rest/controllers/main.py
@@ -138,8 +138,8 @@ class RestController(Controller, metaclass=RestControllerType):
             raise BadRequest()
         return True
 
-    def _process_method(self, service_name, method_name, *args, params=None):
+    def _process_method(self, service_name, method_name, *args, params=None, **kwargs):
         self._validate_method_name(method_name)
         with self.service_component(service_name) as service:
-            result = service.dispatch(method_name, *args, params=params)
+            result = service.dispatch(method_name, *args, params=params, **kwargs)
             return self.make_response(result)

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -329,7 +329,17 @@ class RestApiServiceControllerGenerator(object):
                 default_route = routes[0]
                 rule = Rule(default_route)
                 Map(rules=[rule])
-                if rule.arguments:
+                if rule.arguments and routing["endpoint_params_to_kwargs"]:
+                    method = METHOD_TMPL_WITH_KWARGS.format(
+                        method_name=method_name,
+                        service_name=self._service_name,
+                        service_method_name=name,
+                        args=", ".join("%s=False" % arg for arg in rule.arguments),
+                        args_value=", ".join(
+                            "{}={}".format(arg, arg) for arg in rule.arguments
+                        ),
+                    )
+                elif rule.arguments:
                     method = METHOD_TMPL_WITH_ARGS.format(
                         method_name=method_name,
                         service_name=self._service_name,
@@ -364,6 +374,15 @@ def {method_name}(self, **kwargs):
     )
 """
 
+METHOD_TMPL_WITH_KWARGS = """
+def {method_name}(self, {args}, **kwargs):
+    return self._process_method(
+        "{service_name}",
+        "{service_method_name}",
+        params=kwargs,
+        {args_value},
+    )
+"""
 
 METHOD_TMPL_WITH_ARGS = """
 def {method_name}(self, {args}, **kwargs):

--- a/base_rest/restapi.py
+++ b/base_rest/restapi.py
@@ -12,7 +12,13 @@ from .tools import cerberus_to_json
 
 
 def method(
-    routes, input_param=None, output_param=None, auth=None, cors=None, csrf=False
+    routes,
+    input_param=None,
+    output_param=None,
+    auth=None,
+    cors=None,
+    csrf=False,
+    endpoint_params_to_kwargs=False,
 ):
     """Decorator marking the decorated method as being a handler for
     REST requests. The method must be part of a component inheriting from
@@ -38,6 +44,8 @@ def method(
     :param cors: The Access-Control-Allow-Origin cors directive value.
     :param bool csrf: Whether CSRF protection should be enabled for the route.
                       Defaults to ``False``
+    :param bool endpoint_params_to_kwargs: Pass the query parameters as keyword
+                arguments, following the same logic than Werkzeug
 
     """
 
@@ -54,6 +62,7 @@ def method(
             "routes": _routes,
             "input_param": input_param,
             "output_param": output_param,
+            "endpoint_params_to_kwargs": endpoint_params_to_kwargs,
         }
 
         @functools.wraps(f)

--- a/base_rest_demo/services/partner_new_api_services.py
+++ b/base_rest_demo/services/partner_new_api_services.py
@@ -71,3 +71,13 @@ class PartnerNewApiService(Component):
 
     def _get(self, _id):
         return self.env["res.partner"].browse(_id)
+
+    @restapi.method(
+        [(["/<int:partner_id>/<string:demo_field>/get"], "GET")],
+        output_param=Datamodel("partner.info"),
+        auth="public",
+        endpoint_params_to_kwargs=True,
+    )
+    def get_with_kwargs(self, partner_id=False, demo_field=False):
+        assert demo_field
+        return self.get(partner_id)


### PR DESCRIPTION
With this change, parameters from the url, will be used as kwargs. It will not change the behavior of existing installations
Without this change, if you have a url, with two parameters, sometimes the parameters where received on the wrong order.

So, for example, using "/<int:partner_id>/<string:demo_field>/get", sometimes, the first parameter where the partner_id and sometimes the demo_field.

@lmignon 