### PR TITLE
[13.0][FIX] base_rest: do not crash on missing description

### DIFF
--- a/base_rest/apispec/base_rest_service_apispec.py
+++ b/base_rest/apispec/base_rest_service_apispec.py
@@ -24,7 +24,7 @@ class BaseRestServiceAPISpec(APISpec):
             openapi_version="3.0.0",
             info={
                 "description": textwrap.dedent(
-                    getattr(self._service, "_description", "")
+                    getattr(self._service, "_description", "") or ""
                 )
             },
             servers=self._get_servers(),


### PR DESCRIPTION
The _description field is defined in base.rest.service, as None.
So any service that did not override this value would crash on dedent.
It's a remake of #72

Froward port of #141