### PR TITLE
rest_log: fix _dispatch_exception

### DIFF
--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -43,10 +43,15 @@ class BaseRESTService(AbstractComponent):
             result = super().dispatch(method_name, *args, params=params)
         except exceptions.UserError as orig_exception:
             self._dispatch_exception(
-                RESTServiceUserErrorException, orig_exception, *args, params=params
+                method_name,
+                RESTServiceUserErrorException,
+                orig_exception,
+                *args,
+                params=params,
             )
         except exceptions.ValidationError as orig_exception:
             self._dispatch_exception(
+                method_name,
                 RESTServiceValidationErrorException,
                 orig_exception,
                 *args,
@@ -54,7 +59,11 @@ class BaseRESTService(AbstractComponent):
             )
         except Exception as orig_exception:
             self._dispatch_exception(
-                RESTServiceDispatchException, orig_exception, *args, params=params
+                method_name,
+                RESTServiceDispatchException,
+                orig_exception,
+                *args,
+                params=params,
             )
         log_entry = self._log_call_in_db(
             self.env, request, method_name, *args, params=params, result=result
@@ -64,7 +73,9 @@ class BaseRESTService(AbstractComponent):
             result["log_entry_url"] = log_entry_url
         return result
 
-    def _dispatch_exception(self, exception_klass, orig_exception, *args, params=None):
+    def _dispatch_exception(
+        self, method_name, exception_klass, orig_exception, *args, params=None
+    ):
         tb = traceback.format_exc()
         # TODO: how to test this? Cannot rollback nor use another cursor
         self.env.cr.rollback()
@@ -73,6 +84,7 @@ class BaseRESTService(AbstractComponent):
             log_entry = self._log_call_in_db(
                 env,
                 request,
+                method_name,
                 *args,
                 params=params,
                 traceback=tb,

--- a/rest_log/tests/common.py
+++ b/rest_log/tests/common.py
@@ -4,23 +4,14 @@
 
 import contextlib
 
+from odoo import exceptions
+
 from odoo.addons.base_rest import restapi
-from odoo.addons.base_rest.tests.common import SavepointRestServiceRegistryCase
 from odoo.addons.component.core import Component
 from odoo.addons.website.tools import MockRequest
 
 
-class TestDBLoggingBase(SavepointRestServiceRegistryCase):
-    """Test DB logging for REST calls.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.base_url = cls.env["ir.config_parameter"].get_param("web.base.url")
-        cls.service = cls._get_service(cls)
-        cls.log_model = cls.env["rest.log"].sudo()
-
+class TestDBLoggingMixin(object):
     @staticmethod
     def _get_service(class_or_instance):
         # pylint: disable=R7980
@@ -43,6 +34,16 @@ class TestDBLoggingBase(SavepointRestServiceRegistryCase):
 
             def _get_out_schema(self):
                 return {"name": {"type": "string", "required": True}}
+
+            @restapi.method([(["/fail/<string:how>"], "GET")], auth="public")
+            def fail(self, how):
+                """Test a failure"""
+                exc = {
+                    "value": ValueError,
+                    "validation": exceptions.ValidationError,
+                    "user": exceptions.UserError,
+                }
+                raise exc[how]("Failed as you wanted!")
 
         class_or_instance.comp_registry.load_components("rest_log")
         # class_or_instance._build_services(class_or_instance, LoggedService)


### PR DESCRIPTION
Fix regression caused by #147.
`method_name` was not passed.
Unfortunately there's no 100% test cov for dispatching exception.
I'm gonna fix this soon.

TODO: add tests