### PR TITLE
[13.0][FIX] datamodel: Error when NestedModel inside other field (Example: field.List())

### DIFF
--- a/datamodel/README.rst
+++ b/datamodel/README.rst
@@ -23,7 +23,7 @@ Datamodel
     :target: https://runbot.odoo-community.org/runbot/271/13.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This addon allows you to define simple data models supporting serialization/deserialization
 to/from json
@@ -145,6 +145,9 @@ Contributors
 ~~~~~~~~~~~~
 
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~
@@ -165,7 +168,7 @@ promote its widespread use.
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-lmignon| 
+|maintainer-lmignon|
 
 This module is part of the `OCA/rest-framework <https://github.com/OCA/rest-framework/tree/13.0/datamodel>`_ project on GitHub.
 

--- a/datamodel/fields.py
+++ b/datamodel/fields.py
@@ -30,10 +30,18 @@ class NestedModel(Nested):
     @property
     def schema(self):
         if not self.nested:
-            self.nested = self.parent._env.datamodels[
+            # Get the major parent to avoid error of _env does not exist
+            super_parent = None
+            parent = self
+            while not super_parent:
+                if not hasattr(parent, "parent"):
+                    super_parent = parent
+                    break
+                parent = parent.parent
+            self.nested = super_parent._env.datamodels[
                 self.datamodel_name
             ].__schema_class__
-            self.nested._env = self.parent._env
+            self.nested._env = super_parent._env
         return super(NestedModel, self).schema
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/datamodel/readme/CONTRIBUTORS.rst
+++ b/datamodel/readme/CONTRIBUTORS.rst
@@ -1,1 +1,4 @@
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Carlos Roca

--- a/datamodel/static/description/index.html
+++ b/datamodel/static/description/index.html
@@ -480,13 +480,21 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<ul>
+<li><p class="first">Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</p>
+</li>
+<li><p class="first"><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:</p>
+<blockquote>
 <ul class="simple">
-<li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
+<li>Carlos Roca</li>
+</ul>
+</blockquote>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
Before this patch, when we had a NestedModel inside a field.List the datamodel could not be constructed because the List object hasn't the variable _env.

Now we get the absolute parent to avoid this error and allow to make list of NestedModels.

Capture before the patch:
![image](https://user-images.githubusercontent.com/35952655/118975013-cad0ef00-b973-11eb-97f4-7c07c5d5ab11.png)

Capture after the patch:
![image](https://user-images.githubusercontent.com/35952655/118975196-0966a980-b974-11eb-8151-c2e6178f1c94.png)

cc @Tecnativa TT27860