### PR TITLE
[12.0][CHG] datamodel: Use more permissive licence: AGPL-> LGPL

### DIFF
--- a/base_rest_datamodel/__manifest__.py
+++ b/base_rest_datamodel/__manifest__.py
@@ -1,12 +1,12 @@
 # Copyright 2020 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 {
     "name": "Base Rest Datamodel",
     "summary": """
         Datamodel binding for base_rest""",
     "version": "12.0.2.0.1",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",
     "depends": ["base_rest", "datamodel"],

--- a/datamodel/__manifest__.py
+++ b/datamodel/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2019 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 {
     "name": "Datamodel",
@@ -7,7 +7,7 @@
         This addon allows you to define simple data models supporting
         serialization/deserialization""",
     "version": "12.0.2.0.0",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "development_status": "Beta",
     "author": "ACSONE SA/NV, " "Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],

--- a/datamodel/builder.py
+++ b/datamodel/builder.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Camptocamp SA
 # Copyright 2019 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 """
 

--- a/datamodel/core.py
+++ b/datamodel/core.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Camptocamp SA
 # Copyright 2019 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 import functools
 import logging

--- a/datamodel/datamodels/base.py
+++ b/datamodel/datamodels/base.py
@@ -1,5 +1,5 @@
 # Copyright 2019 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 from ..core import Datamodel
 

--- a/datamodel/fields.py
+++ b/datamodel/fields.py
@@ -1,5 +1,5 @@
 # Copyright 2019 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 """
 
 Fields

--- a/datamodel/tests/common.py
+++ b/datamodel/tests/common.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Camptocamp SA
 # Copyright 2019 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 import copy
 import unittest

--- a/datamodel/tests/test_build_datamodel.py
+++ b/datamodel/tests/test_build_datamodel.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Camptocamp SA
 # Copyright 2019 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 import mock
 from marshmallow_objects.models import Model as MarshmallowModel


### PR DESCRIPTION
The rest of the modules in the rest-framework repo are all licensed under LGPL since https://github.com/OCA/rest-framework/pull/28 with the exception of the `datamodel` and `base_rest_datamodel` which remain licensed under AGPL.

This PR relicenses these modules to LGPL-3. Closes https://github.com/OCA/rest-framework/issues/164