### PR TITLE
[14.0] base_rest multiple http methods and cors OPTIONS

### DIFF
--- a/base_rest/restapi.py
+++ b/base_rest/restapi.py
@@ -43,10 +43,13 @@ def method(
 
     def decorator(f):
         _routes = []
-        for paths, http_method in routes:
+        for paths, http_methods in routes:
             if not isinstance(paths, list):
                 paths = [paths]
-            _routes.append(([p for p in paths], http_method))
+            if not isinstance(http_methods, list):
+                http_methods = [http_methods]
+            for m in http_methods:
+                _routes.append(([p for p in paths], m))
         routing = {
             "csrf": csrf,
             "auth": auth,

--- a/base_rest/restapi.py
+++ b/base_rest/restapi.py
@@ -35,7 +35,9 @@ def method(
                     the `to_response` method with this result and then return
                     the result of this call.
       :param auth: The type of authentication method
-      :param cors: The Access-Control-Allow-Origin cors directive value.
+      :param cors: The Access-Control-Allow-Origin cors directive value. When
+                   set, this automatically adds OPTIONS to allowed http methods
+                   so the Odoo request handler will accept it.
       :param bool csrf: Whether CSRF protection should be enabled for the route.
                         Defaults to ``False``
 
@@ -48,6 +50,8 @@ def method(
                 paths = [paths]
             if not isinstance(http_methods, list):
                 http_methods = [http_methods]
+            if cors and "OPTIONS" not in http_methods:
+                http_methods.append("OPTIONS")
             for m in http_methods:
                 _routes.append(([p for p in paths], m))
         routing = {


### PR DESCRIPTION
- allow multiple http methods when declaring a route
- automatically enable then OPTIONS method when cors is set (otherwise the Odoo request handler rejects it with a 405, which is not good since OPTIONS must be handled correctly when doing cross origin calls in a browser app)