### PR TITLE
[13.0][FIX] fix unit test w/ odoo test suite

### DIFF
--- a/base_rest/tests/common.py
+++ b/base_rest/tests/common.py
@@ -5,6 +5,8 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import copy
+import sys
+import unittest
 
 from odoo import http
 from odoo.tests.common import SavepointCase, TransactionCase, get_db_name
@@ -23,6 +25,19 @@ from odoo.addons.component.tests.common import (
 from ..controllers.main import RestController, _PseudoCollection
 from ..core import RestServicesRegistry, _rest_services_databases
 from ..tools import _inspect_methods
+
+if sys.version_info < (3, 8):
+    # This commit
+    # https://github.com/odoo/odoo/commit/ed831abd7d91ee873a1a92ecea2de316a025754f
+    # introduced a backward imcompatible change
+    # that makes simple unit tests ran through Odoo suite fail
+    # because `doClassCleanups` is not defined.
+    # They defined it on `TreeCase` so... there we go.
+    from odoo.tests.common import TreeCase
+
+    TestCase = TreeCase
+else:
+    TestCase = unittest.TestCase
 
 
 class RegistryMixin(object):

--- a/base_rest/tests/test_cerberus_validator.py
+++ b/base_rest/tests/test_cerberus_validator.py
@@ -10,11 +10,12 @@ from odoo.tests.common import MetaCase
 
 from ..components.cerberus_validator import BaseRestCerberusValidator
 from ..restapi import CerberusValidator
+from .common import TestCase
 
 
-class TestCerberusValidator(unittest.TestCase, MetaCase("DummyCase", (object,), {})):
-    """ Test all the methods that must be implemented by CerberusValidator to
-    be a valid RestMethodParam  """
+class TestCerberusValidator(TestCase, MetaCase("DummyCase", (object,), {})):
+    """Test all the methods that must be implemented by CerberusValidator to
+    be a valid RestMethodParam"""
 
     @classmethod
     def setUpClass(cls):

--- a/datamodel/tests/common.py
+++ b/datamodel/tests/common.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import copy
+import sys
 import unittest
 from contextlib import contextmanager
 
@@ -16,6 +17,19 @@ from ..core import (
     _datamodel_databases,
     _get_addon_name,
 )
+
+if sys.version_info < (3, 8):
+    # This commit
+    # https://github.com/odoo/odoo/commit/ed831abd7d91ee873a1a92ecea2de316a025754f
+    # introduced a backward imcompatible change
+    # that makes simple unit tests ran through Odoo suite fail
+    # because `doClassCleanups` is not defined.
+    # They defined it on `TreeCase` so... there we go.
+    from odoo.tests.common import TreeCase
+
+    TestCase = TreeCase
+else:
+    TestCase = unittest.TestCase
 
 
 @contextmanager
@@ -59,7 +73,7 @@ class DatamodelMixin(object):
 
 
 class TransactionDatamodelCase(common.TransactionCase, DatamodelMixin):
-    """ A TransactionCase that loads all the datamodels
+    """A TransactionCase that loads all the datamodels
 
     It it used like an usual Odoo's TransactionCase, but it ensures
     that all the datamodels of the current addon and its dependencies
@@ -81,7 +95,7 @@ class TransactionDatamodelCase(common.TransactionCase, DatamodelMixin):
 
 
 class SavepointDatamodelCase(common.SavepointCase, DatamodelMixin):
-    """ A SavepointCase that loads all the datamodels
+    """A SavepointCase that loads all the datamodels
 
     It is used like an usual Odoo's SavepointCase, but it ensures
     that all the datamodels of the current addon and its dependencies
@@ -102,10 +116,8 @@ class SavepointDatamodelCase(common.SavepointCase, DatamodelMixin):
         DatamodelMixin.setUp(self)
 
 
-class DatamodelRegistryCase(
-    unittest.TestCase, common.MetaCase("DummyCase", (object,), {})
-):
-    """ This test case can be used as a base for writings tests on datamodels
+class DatamodelRegistryCase(TestCase, common.MetaCase("DummyCase", (object,), {})):
+    """This test case can be used as a base for writings tests on datamodels
 
     This test case is meant to test datamodels in a special datamodel registry,
     where you want to have maximum control on which datamodels are loaded


### PR DESCRIPTION
This commit
odoo/odoo@ed831ab
introduced a backward imcompatible change
that makes simple unit tests ran through Odoo suite fail
because `doClassCleanups` is not defined.
They defined it on `TreeCase` so... there we go.