### PR TITLE
[14.0] base_rest: improve service context and security

### DIFF
--- a/base_rest/apispec/base_rest_service_apispec.py
+++ b/base_rest/apispec/base_rest_service_apispec.py
@@ -8,6 +8,7 @@ from apispec import APISpec
 
 from ..core import _rest_services_databases
 from .rest_method_param_plugin import RestMethodParamPlugin
+from .rest_method_security_plugin import RestMethodSecurityPlugin
 from .restapi_method_route_plugin import RestApiMethodRoutePlugin
 
 
@@ -16,7 +17,7 @@ class BaseRestServiceAPISpec(APISpec):
     APISpec object from base.rest.service component
     """
 
-    def __init__(self, service_component):
+    def __init__(self, service_component, **params):
         self._service = service_component
         super(BaseRestServiceAPISpec, self).__init__(
             title="%s REST services" % self._service._usage,
@@ -31,9 +32,10 @@ class BaseRestServiceAPISpec(APISpec):
             plugins=[
                 RestApiMethodRoutePlugin(self._service),
                 RestMethodParamPlugin(self._service),
+                RestMethodSecurityPlugin(self._service),
             ],
         )
-        self._generate_paths()
+        self._params = params
 
     def _get_servers(self):
         env = self._service.env
@@ -66,7 +68,7 @@ class BaseRestServiceAPISpec(APISpec):
                     routing=routing,
                 )
 
-    def _generate_paths(self):
+    def generate_paths(self):
         for _name, method in inspect.getmembers(self._service, inspect.ismethod):
             routing = getattr(method, "routing", None)
             if not routing:

--- a/base_rest/apispec/rest_method_param_plugin.py
+++ b/base_rest/apispec/rest_method_param_plugin.py
@@ -8,7 +8,8 @@ from ..restapi import RestMethodParam
 
 class RestMethodParamPlugin(BasePlugin):
     """
-    APISpec plugin to generate path from a services method
+    APISpec plugin to generate path parameters and responses from a services
+    method
     """
 
     def __init__(self, service):

--- a/base_rest/apispec/rest_method_security_plugin.py
+++ b/base_rest/apispec/rest_method_security_plugin.py
@@ -1,0 +1,35 @@
+# Copyright 2021 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from apispec import BasePlugin
+
+
+class RestMethodSecurityPlugin(BasePlugin):
+    """
+    APISpec plugin to generate path security from a services method
+    """
+
+    def __init__(self, service):
+        super(RestMethodSecurityPlugin, self).__init__()
+        self._service = service
+
+    def init_spec(self, spec):
+        super(RestMethodSecurityPlugin, self).init_spec(spec)
+        self.spec = spec
+        self.openapi_version = spec.openapi_version
+        user_scheme = {"type": "apiKey", "in": "cookie", "name": "session_id"}
+        spec.components.security_scheme("user", user_scheme)
+
+    def operation_helper(self, path=None, operations=None, **kwargs):
+        routing = kwargs.get("routing")
+        if not routing:
+            super(RestMethodSecurityPlugin, self).operation_helper(
+                path, operations, **kwargs
+            )
+        if not operations:
+            return
+        auth = routing.get("auth", self.spec._params.get("default_auth"))
+        if auth == "user":
+            for _method, params in operations.items():
+                security = params.setdefault("security", [])
+                security.append({"user": []})

--- a/base_rest/components/__init__.py
+++ b/base_rest/components/__init__.py
@@ -1,2 +1,3 @@
 from . import service
+from . import service_context_provider
 from . import cerberus_validator

--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -175,12 +175,17 @@ class BaseRestService(AbstractComponent):
         """
         return {}
 
-    def to_openapi(self):
+    def _get_api_spec(self, **params):
+        return BaseRestServiceAPISpec(self, **params)
+
+    def to_openapi(self, **params):
         """
         Return the description of this REST service as an OpenAPI json document
         :return: json document
         """
-        return BaseRestServiceAPISpec(self).to_dict()
+        api_spec = self._get_api_spec(**params)
+        api_spec.generate_paths()
+        return api_spec.to_dict()
 
     def _get_openapi_default_parameters(self):
         return []

--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -198,3 +198,11 @@ class BaseRestService(AbstractComponent):
                 "requested resource."
             },
         }
+
+    @property
+    def request(self):
+        return self.work.request
+
+    @property
+    def controller(self):
+        return self.work.controller

--- a/base_rest/components/service_context_provider.py
+++ b/base_rest/components/service_context_provider.py
@@ -1,0 +1,17 @@
+# Copyright 2021 ACSONE SA/NV
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+from odoo.addons.component.core import Component
+
+
+class BaseRestServiceContextProvider(Component):
+    _name = "base.rest.service.context.provider"
+    _usage = "component_context_provider"
+
+    @property
+    def request(self):
+        return self.work.request
+
+    def _get_component_context(self):
+        return {"request": self.request}

--- a/base_rest/controllers/api_docs.py
+++ b/base_rest/controllers/api_docs.py
@@ -34,8 +34,14 @@ class ApiDocsController(Controller):
 
     @route("/api-docs/<path:collection>/<string:service_name>.json", auth="public")
     def api(self, collection, service_name):
-        with self.service_component(collection, service_name) as service:
-            return self.make_json_response(service.to_openapi())
+        with self.service_and_controller_class(collection, service_name) as (
+            service,
+            controller_class,
+        ):
+            openapi_doc = service.to_openapi(
+                default_auth=controller_class._default_auth
+            )
+            return self.make_json_response(openapi_doc)
 
     def _get_api_urls(self):
         """
@@ -74,18 +80,21 @@ class ApiDocsController(Controller):
         return services
 
     @contextmanager
-    def service_component(self, collection_path, service_name):
+    def service_and_controller_class(self, collection_path, service_name):
         """
         Return the component that implements the methods of the requested
         service.
         :param collection_path:
         :param service_name:
-        :return: an instance of invader.service component
+        :return: an instance of invader.service component,
+                 the base controller class serving the service
         """
-        collection_name = self._get_collection_name(collection_path)
+        services_spec = self._get_services_specs(collection_path)
+        collection_name = services_spec["collection_name"]
+        controller_class = services_spec["controller_class"]
         with self.work_on_component(collection_name) as work:
             service = work.component(usage=service_name)
-            yield service
+            yield service, controller_class
 
     @contextmanager
     def work_on_component(self, collection_name):
@@ -97,6 +106,10 @@ class ApiDocsController(Controller):
 
         collection = _PseudoCollection(collection_name, request.env)
         yield WorkContext(model_name="rest.service.registration", collection=collection)
+
+    def _get_services_specs(self, path):
+        services_registry = _rest_services_databases.get(request.env.cr.dbname, {})
+        return services_registry["/" + path + "/"]
 
     def _get_collection_name(self, name):
         services_registry = _rest_services_databases.get(request.env.cr.dbname, {})

--- a/base_rest/controllers/main.py
+++ b/base_rest/controllers/main.py
@@ -44,8 +44,7 @@ class RestControllerType(ControllerType):
         root_path = getattr(cls, "_root_path", None)
         collection_name = getattr(cls, "_collection_name", None)
         if root_path and collection_name:
-            if not hasattr(cls, "_module"):
-                cls._module = _get_addon_name(cls.__module__)
+            cls._module = _get_addon_name(cls.__module__)
             _rest_controllers_per_module[cls._module].append(
                 {
                     "root_path": root_path,
@@ -79,13 +78,23 @@ class RestController(Controller, metaclass=RestControllerType):
     # Whether CSRF protection should be enabled for the route.
     _csrf = False
 
+    _component_context_provider = "component_context_provider"
+
     def _get_component_context(self):
         """
         This method can be inherited to add parameter into the component
         context
         :return: dict of key value.
         """
-        return {"request": request}
+        collection = self.collection
+        work = WorkContext(
+            model_name="rest.service.registration",
+            collection=collection,
+            request=request,
+            controller=self,
+        )
+        provider = work.component(usage=self._component_context_provider)
+        return provider._get_component_context()
 
     def make_response(self, data):
         if isinstance(data, Response):

--- a/base_rest/controllers/main.py
+++ b/base_rest/controllers/main.py
@@ -52,31 +52,79 @@ class RestControllerType(ControllerType):
                     "controller_class": cls,
                 }
             )
+            _logger.info(
+                "Added rest controller %s for module %s",
+                _rest_controllers_per_module[cls._module][-1],
+                cls._module,
+            )
 
 
 class RestController(Controller, metaclass=RestControllerType):
     """Generic REST Controller
 
-    This controller provides generic routes conform to commen REST usages.
-    You must inherit of this controller into your code to register your REST
-    routes. At the same time you must fill 2 required informations:
+    This controller is the base controller used by as base controller for all the REST
+    controller generated from the service components.
+
+    You must inherit of this controller into your code to register the root path
+    used to serve all the services defined for the given collection name.
+    This registration requires 2 parameters:
 
     _root_path:
     _collection_name:
 
+    Only one controller by _collection_name, _root_path should exists into an
+    odoo database. If more than one controller exists, a warning is issued into
+    the log at startup and the concrete controller used as base class
+    for the services registered into the collection name and served at the
+    root path is not predictable.
+
+    Module A:
+        class ControllerA(RestController):
+            _root_path='/my_path/'
+            _collection_name='my_services_collection'
+
+    Module B depends A:                               A
+        class ControllerB(ControllerA):             /  \
+            pass                                   B    C
+                                                  /
+    Module C depends A:                          D
+        class ControllerC(ControllerA):
+            pass
+
+    Module D depends B:
+        class ControllerB(ControllerB):
+            pass
+
+    In the preceding illustration, services in module C will never be served
+    by controller D or B. Therefore if the generic dispatch method is overridden
+    in  B or D, this override wil never apply to services in C since in Odoo
+    controllers are not designed to be inherited. That's why it's an error
+    to have more than one controller registered for the same root path and
+    collection name.
+
+    The following properties can be specified to define common properties to
+    apply to generated REST routes.
+
+    _default_auth: The default authentication to apply to all pre defined routes.
+                    default: 'user'
+    _default_cors: The default Access-Control-Allow-Origin cors directive value.
+                   default: None
+    _default_csrf: Whether CSRF protection should be enabled for the route.
+                   default: False
+    _default_save_session: Whether session should be saved into the session store
+                           default: True
     """
 
     _root_path = None
     _collection_name = None
     # The default authentication to apply to all pre defined routes.
     _default_auth = "user"
-    # You can use this parameter to specify an authentication method by HTTP
-    # method ie: {'GET': None, 'POST': 'user'}
-    _auth_by_method = {}
-    # The default The Access-Control-Allow-Origin cors directive value.
-    _cors = None
+    # The default Access-Control-Allow-Origin cors directive value.
+    _default_cors = None
     # Whether CSRF protection should be enabled for the route.
-    _csrf = False
+    _default_csrf = False
+    # Whether session should be saved into the session store
+    _default_save_session = True
 
     _component_context_provider = "component_context_provider"
 

--- a/base_rest/tests/common.py
+++ b/base_rest/tests/common.py
@@ -103,12 +103,18 @@ class RestServiceRegistryCase(ComponentRegistryCase):
             _collection_name = class_or_instance._collection_name
             _default_auth = "public"
 
-            @http.route("/my_controller_route_without_auth")
-            def my_controller_route_without_auth(self):
+            @http.route("/my_controller_route_without")
+            def my_controller_route_without(self):
                 return {}
 
-            @http.route("/my_controller_route_with_auth_public", auth="public")
-            def my_controller_route_with_auth_public(self):
+            @http.route(
+                "/my_controller_route_with",
+                auth="public",
+                cors="http://with_cors",
+                csrf="False",
+                save_session="False",
+            )
+            def my_controller_route_with(self):
                 return {}
 
             @http.route("/my_controller_route_without_auth_2", auth=None)
@@ -117,8 +123,8 @@ class RestServiceRegistryCase(ComponentRegistryCase):
 
         class_or_instance._BaseTestController = BaseTestController
         class_or_instance._controller_route_method_names = {
-            "my_controller_route_without_auth",
-            "my_controller_route_with_auth_public",
+            "my_controller_route_without",
+            "my_controller_route_with",
             "my_controller_route_without_auth_2",
         }
 

--- a/base_rest/tests/common.py
+++ b/base_rest/tests/common.py
@@ -21,7 +21,11 @@ from odoo.addons.component.tests.common import (
 )
 
 from ..controllers.main import RestController, _PseudoCollection
-from ..core import RestServicesRegistry, _rest_services_databases
+from ..core import (
+    RestServicesRegistry,
+    _rest_controllers_per_module,
+    _rest_services_databases,
+)
 from ..tools import _inspect_methods
 
 
@@ -62,6 +66,9 @@ class RestServiceRegistryCase(ComponentRegistryCase):
 
         class_or_instance._controllers_per_module = copy.deepcopy(
             http.controllers_per_module
+        )
+        class_or_instance._original_addon_rest_controllers_per_module = copy.deepcopy(
+            _rest_controllers_per_module[_get_addon_name(class_or_instance.__module__)]
         )
         db_name = get_db_name()
 
@@ -137,6 +144,10 @@ class RestServiceRegistryCase(ComponentRegistryCase):
         _rest_services_databases[
             db_name
         ] = class_or_instance._original_services_registry
+        class_or_instance._service_registry = {}
+        _rest_controllers_per_module[
+            _get_addon_name(class_or_instance.__module__)
+        ] = class_or_instance._original_addon_rest_controllers_per_module
 
     @staticmethod
     def _build_services(class_or_instance, *classes):

--- a/base_rest_datamodel/__manifest__.py
+++ b/base_rest_datamodel/__manifest__.py
@@ -12,6 +12,6 @@
     "depends": ["base_rest", "datamodel"],
     "data": [],
     "demo": [],
-    "external_dependencies": {"python": ["apispec"]},
+    "external_dependencies": {"python": ["apispec", "marshmallow"]},
     "installable": True,
 }

--- a/base_rest_demo/tests/data/partner_api.json
+++ b/base_rest_demo/tests/data/partner_api.json
@@ -37,7 +37,12 @@
           "403": {
             "description": "You don't have the permission to access the requested resource."
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -192,7 +197,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       }
     },
     "/": {
@@ -336,7 +346,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "get": {
         "summary": "\nSearh partner by name\n",
@@ -441,7 +456,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       }
     },
     "/{id}/get": {
@@ -524,7 +544,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -618,7 +643,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -771,7 +801,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "put": {
         "summary": "\nUpdate partner informations\n",
@@ -913,7 +948,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       }
     },
     "/search": {
@@ -1020,7 +1060,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       }
     },
     "/{id}/update": {
@@ -1164,7 +1209,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -1179,5 +1229,14 @@
       ]
     }
   },
-  "openapi": "3.0.0"
+  "openapi": "3.0.0",
+  "components": {
+    "securitySchemes": {
+      "user": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "session_id"
+      }
+    }
+  }
 }

--- a/base_rest_demo/tests/data/partner_image_api.json
+++ b/base_rest_demo/tests/data/partner_image_api.json
@@ -39,7 +39,12 @@
           "403": {
             "description": "You don't have the permission to access the requested resource."
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -82,7 +87,12 @@
           "403": {
             "description": "You don't have the permission to access the requested resource."
           }
-        }
+        },
+        "security": [
+          {
+            "user": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -97,5 +107,14 @@
       ]
     }
   },
-  "openapi": "3.0.0"
+  "openapi": "3.0.0",
+  "components": {
+    "securitySchemes": {
+      "user": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "session_id"
+      }
+    }
+  }
 }

--- a/base_rest_demo/tests/data/ping_api.json
+++ b/base_rest_demo/tests/data/ping_api.json
@@ -658,5 +658,14 @@
       ]
     }
   },
-  "openapi": "3.0.0"
+  "openapi": "3.0.0",
+  "components": {
+    "securitySchemes": {
+      "user": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "session_id"
+      }
+    }
+  }
 }

--- a/base_rest_demo/tests/test_openapi.py
+++ b/base_rest_demo/tests/test_openapi.py
@@ -16,21 +16,21 @@ class TestOpenAPI(CommonCase):
 
     def test_partner_api(self):
         partner_service = self.private_services_env.component(usage="partner")
-        openapi_def = partner_service.to_openapi()
+        openapi_def = partner_service.to_openapi(default_auth="user")
         canonical_def = get_canonical_json("partner_api.json")
         self._fix_server_url(canonical_def)
         self.assertFalse(jsondiff.diff(openapi_def, canonical_def))
 
     def test_ping_api(self):
         ping_service = self.public_services_env.component(usage="ping")
-        openapi_def = ping_service.to_openapi()
+        openapi_def = ping_service.to_openapi(default_auth="public")
         canonical_def = get_canonical_json("ping_api.json")
         self._fix_server_url(canonical_def)
         self.assertFalse(jsondiff.diff(openapi_def, canonical_def))
 
     def test_partner_image_api(self):
         partner_service = self.private_services_env.component(usage="partner_image")
-        openapi_def = partner_service.to_openapi()
+        openapi_def = partner_service.to_openapi(default_auth="user")
         canonical_def = get_canonical_json("partner_image_api.json")
         self._fix_server_url(canonical_def)
         self.assertFalse(jsondiff.diff(openapi_def, canonical_def))

--- a/base_rest_demo/tests/test_openapi.py
+++ b/base_rest_demo/tests/test_openapi.py
@@ -14,9 +14,22 @@ class TestOpenAPI(CommonCase):
         url.replace("http://localhost:8069", self.base_url)
         openapi_def["servers"][0]["url"] = url
 
+    def _fix_openapi_components(self, openapi_def):
+        """
+        Remove additional components that could be added by others addons than
+        base_rest
+        """
+        security_components = openapi_def.get("components", {}).get(
+            "securitySchemes", {}
+        )
+        unknow_keys = set(security_components.keys()) - {"user"}
+        for key in unknow_keys:
+            del security_components[key]
+
     def test_partner_api(self):
         partner_service = self.private_services_env.component(usage="partner")
         openapi_def = partner_service.to_openapi(default_auth="user")
+        self._fix_openapi_components(openapi_def)
         canonical_def = get_canonical_json("partner_api.json")
         self._fix_server_url(canonical_def)
         self.assertFalse(jsondiff.diff(openapi_def, canonical_def))
@@ -24,6 +37,7 @@ class TestOpenAPI(CommonCase):
     def test_ping_api(self):
         ping_service = self.public_services_env.component(usage="ping")
         openapi_def = ping_service.to_openapi(default_auth="public")
+        self._fix_openapi_components(openapi_def)
         canonical_def = get_canonical_json("ping_api.json")
         self._fix_server_url(canonical_def)
         self.assertFalse(jsondiff.diff(openapi_def, canonical_def))
@@ -31,6 +45,7 @@ class TestOpenAPI(CommonCase):
     def test_partner_image_api(self):
         partner_service = self.private_services_env.component(usage="partner_image")
         openapi_def = partner_service.to_openapi(default_auth="user")
+        self._fix_openapi_components(openapi_def)
         canonical_def = get_canonical_json("partner_image_api.json")
         self._fix_server_url(canonical_def)
         self.assertFalse(jsondiff.diff(openapi_def, canonical_def))


### PR DESCRIPTION
Improvements:

* This PR introduces a new component `BaseRestServiceContextProvider`to be used to extend the component context that will be provided to the service layer when a method is called. Prior to this change, the only way to extend the context was to extend the default method `_get_component_context` provided by the RestController class. Since only one RestController should be registered into the database for a root_path and collection name, this mechanism give you the opportunity to extend the context provided by a base addon into specialized addons
*  If 2 `RestController`s are registered for the same root_path and  collection name, an error is now printed into the log at server startup
* It's now possible to output into the openapi doc, the authentication mechanism required by a method.
* The management of defaults route attributes defined on the RestController has been improved (applied only if not provided by a `@http.route` nor `|restapi.method`decorators)  
* Add a new kind of restapi method parameter `BinaryData`to be used to decalre method requesting/returning files