### PR TITLE
[14.0][IMP] base_rest_datamodel: allow to receive partial datamodels as params

### DIFF
--- a/base_rest_datamodel/restapi.py
+++ b/base_rest_datamodel/restapi.py
@@ -12,21 +12,29 @@ from odoo.addons.base_rest import restapi
 
 
 class Datamodel(restapi.RestMethodParam):
-    def __init__(self, name, is_list=False):
+    def __init__(self, name, is_list=False, partial=None):
         """
 
-        :param name: The datamdel name
+        :param name: The datamodel name
         :param is_list: Should be set to True if params is a collection so that
                         the object will be de/serialized from/to a list
+        :param partial: Whether to ignore missing fields and not require
+            any fields declared. Propagates down to ``Nested`` fields as well. If
+            its value is an iterable, only missing fields listed in that iterable
+            will be ignored. Use dot delimiters to specify nested fields.
         """
         self._name = name
         self._is_list = is_list
+        self._partial = partial
 
     def from_params(self, service, params):
         ModelClass = service.env.datamodels[self._name]
         try:
             return ModelClass.load(
-                params, many=self._is_list, unknown=marshmallow.EXCLUDE
+                params,
+                many=self._is_list,
+                unknown=marshmallow.EXCLUDE,
+                partial=self._partial,
             )
         except ValidationError as ve:
             raise UserError(_("BadRequest %s") % ve.messages)

--- a/base_rest_datamodel/tests/__init__.py
+++ b/base_rest_datamodel/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_response
+from . import test_from_params

--- a/base_rest_datamodel/tests/test_from_params.py
+++ b/base_rest_datamodel/tests/test_from_params.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Wakari SRL
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import mock
+
+from odoo.exceptions import UserError
+
+from odoo.addons.datamodel import fields
+from odoo.addons.datamodel.core import Datamodel
+from odoo.addons.datamodel.tests import common
+
+from .. import restapi
+
+
+class TestDataModel(common.DatamodelRegistryCase):
+    def setUp(self):
+        super(TestDataModel, self).setUp()
+
+        class Datamodel1(Datamodel):
+            _name = "datamodel1"
+
+            name = fields.String(required=True, allow_none=False)
+            description = fields.String(required=False)
+
+        Datamodel1._build_datamodel(self.datamodel_registry)
+
+    def _from_params(self, datamodel_name, params, **kwargs):
+        restapi_datamodel = restapi.Datamodel(datamodel_name, **kwargs)
+        mock_service = mock.Mock()
+        mock_service.env = self.env
+        return restapi_datamodel.from_params(mock_service, params)
+
+    def test_from_params(self):
+        params = {"name": "Instance Name", "description": "Instance Description"}
+        instance = self._from_params("datamodel1", params)
+        self.assertEqual(instance.name, params["name"])
+        self.assertEqual(instance.description, params["description"])
+
+    def test_from_params_missing_optional_field(self):
+        params = {"name": "Instance Name"}
+        instance = self._from_params("datamodel1", params)
+        self.assertEqual(instance.name, params["name"])
+        self.assertIsNone(instance.description)
+
+    def test_from_params_missing_required_field(self):
+        msg = r"BadRequest {'name': \['Missing data for required field.'\]}"
+        with self.assertRaisesRegex(UserError, msg):
+            self._from_params("datamodel1", {"description": "Instance Description"})
+
+    def test_from_partial_params_missing_required_field(self):
+        params = {"description": "Instance Description"}
+        instance = self._from_params("datamodel1", params, partial=True)
+        self.assertEqual(instance.description, params["description"])
+        self.assertIsNone(instance.name)


### PR DESCRIPTION
Forward port of PR https://github.com/OCA/rest-framework/pull/170

In particular, this feature allows one to use datamodels to make partial updates through `PUT` requests. In this case, the endpoint declaration would look like this:

```python
    @restapi.method(
        [(["/"], "PUT")],
        input_param=Datamodel("partner.info", partial=True),
        output_param=Datamodel("partner.info"),
    )
```

If `partial` is not set (or without this feature), the params sent by the client in the request must contain values for all the fields declared as `required` in the datamodel. Note that it uses an existing functionality of `marshmallow_objects`, as a call to `dump` of a `Datamodel` declared as `partial` would contain only the subset of fields provided in the params.