### PR TITLE
[14.0][FIX] base_rest_datamodel: modify validation of responses to allow `dump_only` fields

### DIFF
--- a/base_rest_datamodel/restapi.py
+++ b/base_rest_datamodel/restapi.py
@@ -37,7 +37,9 @@ class Datamodel(restapi.RestMethodParam):
             json = [i.dump() for i in result]
         else:
             json = result.dump()
-        errors = ModelClass.validate(json, many=self._is_list)
+        errors = ModelClass.validate(
+            json, many=self._is_list, unknown=marshmallow.EXCLUDE
+        )
         if errors:
             raise SystemError(_("Invalid Response %s") % errors)
         return json

--- a/base_rest_datamodel/tests/__init__.py
+++ b/base_rest_datamodel/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_response

--- a/base_rest_datamodel/tests/test_response.py
+++ b/base_rest_datamodel/tests/test_response.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Wakari SRL
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import marshmallow
+import mock
+
+from odoo.addons.base_rest_datamodel import restapi
+from odoo.addons.datamodel import fields
+from odoo.addons.datamodel.core import Datamodel
+from odoo.addons.datamodel.tests import common
+
+
+class TestDataModel(common.DatamodelRegistryCase):
+    def _to_response(self, instance):
+        restapi_datamodel = restapi.Datamodel(instance._name)
+        mock_service = mock.Mock()
+        mock_service.env = self.env
+        return restapi_datamodel.to_response(mock_service, instance)
+
+    def test_to_response(self):
+        class Datamodel1(Datamodel):
+            _name = "datamodel1"
+
+            name = fields.String(required=True, allow_none=False)
+
+        Datamodel1._build_datamodel(self.datamodel_registry)
+        instance = self.env.datamodels["datamodel1"](name="Instance 1")
+        res = self._to_response(instance)
+        self.assertEqual(res["name"], instance.name)
+
+    def test_to_response_dump_only(self):
+        class Datamodel2(Datamodel):
+            _name = "datamodel2"
+
+            name = fields.String(required=True, allow_none=False, dump_only=True)
+
+        Datamodel2._build_datamodel(self.datamodel_registry)
+        schema = self.env.datamodels["datamodel2"].get_schema()
+        self.assertEqual(schema.unknown, "raise")
+        msg = r"{'name': \['Unknown field.'\]}"
+        with self.assertRaisesRegex(marshmallow.exceptions.ValidationError, msg):
+            # confirmation that "name" cannot be loaded
+            self.env.datamodels["datamodel2"].load({"name": "Failure"})
+        instance = self.env.datamodels["datamodel2"](name="Instance 2")
+        res = self._to_response(instance)
+        self.assertEqual(res["name"], instance.name)
+        # schema 'unknown' is back to "raise"
+        self.assertEqual(schema.unknown, "raise")
+
+    def test_to_response_dump_only_nested(self):
+        class Datamodel3(Datamodel):
+            _name = "datamodel3"
+
+            child = fields.NestedModel("nested_datamodel")
+
+        class NestedDatamodel(Datamodel):
+            _name = "nested_datamodel"
+
+            name = fields.String(required=True, allow_none=False, dump_only=True)
+
+        NestedDatamodel._build_datamodel(self.datamodel_registry)
+        Datamodel3._build_datamodel(self.datamodel_registry)
+        for datamodel_name in ("datamodel3", "nested_datamodel"):
+            schema = self.env.datamodels[datamodel_name].get_schema()
+            self.assertEqual(schema.unknown, "raise")
+        msg = r"{'name': \['Unknown field.'\]}"
+        with self.assertRaisesRegex(marshmallow.exceptions.ValidationError, msg):
+            # confirmation that child "name" cannot be loaded
+            self.env.datamodels["datamodel3"].load({"child": {"name": "Failure"}})
+        child_instance = NestedDatamodel(name="Child Instance")
+        instance = self.env.datamodels["datamodel3"](child=child_instance)
+        res = self._to_response(instance)
+        self.assertEqual(res["child"]["name"], child_instance.name)
+        for datamodel_name in ("datamodel3", "nested_datamodel"):
+            schema = self.env.datamodels[datamodel_name].get_schema()
+            # schema 'unknown' is back to "raise"
+            self.assertEqual(schema.unknown, "raise")

--- a/base_rest_demo/datamodels/partner_info.py
+++ b/base_rest_demo/datamodels/partner_info.py
@@ -18,4 +18,4 @@ class PartnerInfo(Datamodel):
     phone = fields.String(required=False, allow_none=True)
     state = NestedModel("state.info")
     country = NestedModel("country.info")
-    is_componay = fields.Boolean(required=False, allow_none=False)
+    is_company = fields.Boolean(required=False, allow_none=False)


### PR DESCRIPTION
Forward port of PR https://github.com/OCA/rest-framework/pull/169