### PR TITLE
[14.0] fwd port of PR #147

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -52,6 +52,8 @@ class JSONEncoder(json.JSONEncoder):
             return obj.isoformat()
         elif isinstance(obj, decimal.Decimal):
             return float(obj)
+        elif isinstance(obj, set):
+            return tuple(obj)
         return super(JSONEncoder, self).default(obj)
 
 

--- a/base_rest/tests/common.py
+++ b/base_rest/tests/common.py
@@ -5,6 +5,8 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import copy
+import sys
+import unittest
 
 from odoo import http
 from odoo.tests.common import SavepointCase, TransactionCase, get_db_name
@@ -27,6 +29,19 @@ from ..core import (
     _rest_services_databases,
 )
 from ..tools import _inspect_methods
+
+if sys.version_info < (3, 8):
+    # This commit
+    # https://github.com/odoo/odoo/commit/ed831abd7d91ee873a1a92ecea2de316a025754f
+    # introduced a backward imcompatible change
+    # that makes simple unit tests ran through Odoo suite fail
+    # because `doClassCleanups` is not defined.
+    # They defined it on `TreeCase` so... there we go.
+    from odoo.tests.common import TreeCase
+
+    TestCase = TreeCase
+else:
+    TestCase = unittest.TestCase
 
 
 class RegistryMixin(object):

--- a/base_rest/tests/test_cerberus_validator.py
+++ b/base_rest/tests/test_cerberus_validator.py
@@ -10,9 +10,10 @@ from odoo.tests.common import MetaCase, TreeCase
 
 from ..components.cerberus_validator import BaseRestCerberusValidator
 from ..restapi import CerberusValidator
+from .common import TestCase
 
 
-class TestCerberusValidator(TreeCase, MetaCase("DummyCase", (object,), {})):
+class TestCerberusValidator(TestCase, MetaCase("DummyCase", (object,), {})):
     """Test all the methods that must be implemented by CerberusValidator to
     be a valid RestMethodParam"""
 

--- a/rest_log/README.rst
+++ b/rest_log/README.rst
@@ -63,6 +63,24 @@ If the value is set to 0, the logs are not stored at all.
 
 Logged data is: request URL and method, parameters, headers, result or error.
 
+
+Logs activation
+~~~~~~~~~~~~~~~
+
+You have 2 ways to activate logging:
+
+* on the service component set `_log_calls_in_db = True`
+* via configuration
+
+In the 1st case, calls will be always be logged.
+
+In the 2nd case you can set ``rest.log.active`` param as::
+
+    `collection_name`  # enable for all endpoints of the collection
+    `collection_name.usage`  # enable for specific endpoints
+    `collection_name.usage.endpoint`  # enable for specific endpoints
+    `collection_name*:state`  # enable only for specific state (success, failed)
+
 Changelog
 =========
 

--- a/rest_log/README.rst
+++ b/rest_log/README.rst
@@ -32,7 +32,8 @@ This module add DB logging for REST requests.
 It also inject in the response the URL of the log entry created.
 
 NOTE: this feature was implemented initially inside shopfloor app.
-If shopfloor is installed, log records will be copied from its table.
+Up to version 13.0.1.2.1 of this module,
+if shopfloor is installed, log records will be copied from its table.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.

--- a/rest_log/__init__.py
+++ b/rest_log/__init__.py
@@ -1,3 +1,2 @@
 from . import models
 from . import components
-from .hooks import post_init_hook

--- a/rest_log/__manifest__.py
+++ b/rest_log/__manifest__.py
@@ -20,5 +20,4 @@
         "views/rest_log_views.xml",
         "views/menu.xml",
     ],
-    "post_init_hook": "post_init_hook",
 }

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -43,10 +43,15 @@ class BaseRESTService(AbstractComponent):
             result = super().dispatch(method_name, *args, params=params)
         except exceptions.UserError as orig_exception:
             self._dispatch_exception(
-                RESTServiceUserErrorException, orig_exception, *args, params=params
+                method_name,
+                RESTServiceUserErrorException,
+                orig_exception,
+                *args,
+                params=params,
             )
         except exceptions.ValidationError as orig_exception:
             self._dispatch_exception(
+                method_name,
                 RESTServiceValidationErrorException,
                 orig_exception,
                 *args,
@@ -54,7 +59,11 @@ class BaseRESTService(AbstractComponent):
             )
         except Exception as orig_exception:
             self._dispatch_exception(
-                RESTServiceDispatchException, orig_exception, *args, params=params
+                method_name,
+                RESTServiceDispatchException,
+                orig_exception,
+                *args,
+                params=params,
             )
         log_entry = self._log_call_in_db(
             self.env, request, method_name, *args, params=params, result=result
@@ -64,7 +73,9 @@ class BaseRESTService(AbstractComponent):
             result["log_entry_url"] = log_entry_url
         return result
 
-    def _dispatch_exception(self, exception_klass, orig_exception, *args, params=None):
+    def _dispatch_exception(
+        self, method_name, exception_klass, orig_exception, *args, params=None
+    ):
         tb = traceback.format_exc()
         # TODO: how to test this? Cannot rollback nor use another cursor
         self.env.cr.rollback()
@@ -73,6 +84,7 @@ class BaseRESTService(AbstractComponent):
             log_entry = self._log_call_in_db(
                 env,
                 request,
+                method_name,
                 *args,
                 params=params,
                 traceback=tb,

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -11,6 +11,7 @@ from werkzeug.urls import url_encode, url_join
 from odoo import exceptions, registry
 from odoo.http import request
 
+from odoo.addons.base_rest.http import JSONEncoder
 from odoo.addons.component.core import AbstractComponent
 
 from ..exceptions import (
@@ -18,6 +19,11 @@ from ..exceptions import (
     RESTServiceUserErrorException,
     RESTServiceValidationErrorException,
 )
+
+
+def json_dump(data):
+    """Encode data to JSON as we like."""
+    return json.dumps(data, cls=JSONEncoder, indent=4, sort_keys=True)
 
 
 class BaseRESTService(AbstractComponent):
@@ -118,9 +124,9 @@ class BaseRESTService(AbstractComponent):
             "collection": self._collection,
             "request_url": httprequest.url,
             "request_method": httprequest.method,
-            "params": json.dumps(params, indent=4, sort_keys=True),
-            "headers": json.dumps(headers, indent=4, sort_keys=True),
-            "result": json.dumps(result, indent=4, sort_keys=True),
+            "params": json_dump(params),
+            "headers": json_dump(headers),
+            "result": json_dump(result),
             "error": error,
             "exception_name": exception_name,
             "exception_message": exception_message,

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -115,6 +115,7 @@ class BaseRESTService(AbstractComponent):
                 exception_name = orig_exception.__module__ + "." + exception_name
             exception_message = self._get_exception_message(orig_exception)
         return {
+            "collection": self._collection,
             "request_url": httprequest.url,
             "request_method": httprequest.method,
             "params": json.dumps(params, indent=4, sort_keys=True),

--- a/rest_log/i18n/rest_log.pot
+++ b/rest_log/i18n/rest_log.pot
@@ -21,6 +21,12 @@ msgid "Auto-vacuum REST Logs"
 msgstr ""
 
 #. module: rest_log
+#: model:ir.model.fields,field_description:rest_log.field_rest_log__collection
+#: model_terms:ir.ui.view,arch_db:rest_log.rest_log_search_view
+msgid "Collection"
+msgstr ""
+
+#. module: rest_log
 #: model:ir.model.fields,field_description:rest_log.field_rest_log__create_uid
 msgid "Created by"
 msgstr ""

--- a/rest_log/models/rest_log.py
+++ b/rest_log/models/rest_log.py
@@ -25,6 +25,7 @@ class RESTLog(models.Model):
         "UnboundLocalError": "severe",
     }
 
+    collection = fields.Char(index=True)
     request_url = fields.Char(readonly=True, string="Request URL")
     request_method = fields.Char(readonly=True)
     params = fields.Text(readonly=True)

--- a/rest_log/models/rest_log.py
+++ b/rest_log/models/rest_log.py
@@ -128,3 +128,52 @@ class RESTLog(models.Model):
         if logs:
             logs.unlink()
         return True
+
+    def _get_log_active_param(self):
+        param = self.env["ir.config_parameter"].sudo().get_param("rest.log.active")
+        return param.strip() if param else ""
+
+    @tools.ormcache("self._get_log_active_param()")
+    def _get_log_active_conf(self):
+        """Compute log active configuration.
+
+        Possible configuration contains a CSV like this:
+
+            `collection_name` -> enable for all endpoints of the collection
+            `collection_name.usage` -> enable for specific endpoints
+            `collection_name.usage.endpoint` -> enable for specific endpoints
+            `collection_name*:state` -> enable only for specific state (success, failed)
+
+        By default matching keys are enabled for all states.
+
+        :return: mapping by matching key / enabled states
+        """
+        param = self._get_log_active_param()
+        conf = {}
+        lines = [x.strip() for x in param.split(",") if x.strip()]
+        for line in lines:
+            bits = [x.strip() for x in line.split(":") if x.strip()]
+            if len(bits) > 1:
+                match_key = bits[0]
+                # fmt: off
+                states = (bits[1], )
+                # fmt: on
+            else:
+                match_key = line
+                states = ("success", "failed")
+            conf[match_key] = states
+        return conf
+
+    @api.model
+    def _get_matching_active_conf(self, collection, usage, method_name):
+        """Retrieve conf matching current service and method.
+        """
+        conf = self._get_log_active_conf()
+        candidates = (
+            collection + "." + usage + "." + method_name,
+            collection + "." + usage,
+            collection,
+        )
+        for candidate in candidates:
+            if conf.get(candidate):
+                return conf.get(candidate)

--- a/rest_log/readme/CONFIGURE.rst
+++ b/rest_log/readme/CONFIGURE.rst
@@ -13,3 +13,21 @@ You can change the duration of the retention by changing the System Parameter
 If the value is set to 0, the logs are not stored at all.
 
 Logged data is: request URL and method, parameters, headers, result or error.
+
+
+Logs activation
+~~~~~~~~~~~~~~~
+
+You have 2 ways to activate logging:
+
+* on the service component set `_log_calls_in_db = True`
+* via configuration
+
+In the 1st case, calls will be always be logged.
+
+In the 2nd case you can set ``rest.log.active`` param as::
+
+    `collection_name`  # enable for all endpoints of the collection
+    `collection_name.usage`  # enable for specific endpoints
+    `collection_name.usage.endpoint`  # enable for specific endpoints
+    `collection_name*:state`  # enable only for specific state (success, failed)

--- a/rest_log/readme/DESCRIPTION.rst
+++ b/rest_log/readme/DESCRIPTION.rst
@@ -5,4 +5,5 @@ This module add DB logging for REST requests.
 It also inject in the response the URL of the log entry created.
 
 NOTE: this feature was implemented initially inside shopfloor app.
-If shopfloor is installed, log records will be copied from its table.
+Up to version 13.0.1.2.1 of this module,
+if shopfloor is installed, log records will be copied from its table.

--- a/rest_log/static/description/index.html
+++ b/rest_log/static/description/index.html
@@ -385,18 +385,19 @@ Only for development or testing purpose, do not use in production.
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id2">Configuration</a><ul>
 <li><a class="reference internal" href="#logs-retention" id="id3">Logs retention</a></li>
+<li><a class="reference internal" href="#logs-activation" id="id4">Logs activation</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#changelog" id="id4">Changelog</a><ul>
-<li><a class="reference internal" href="#id1" id="id5">13.0.1.0.0</a></li>
+<li><a class="reference internal" href="#changelog" id="id5">Changelog</a><ul>
+<li><a class="reference internal" href="#id1" id="id6">13.0.1.0.0</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="id6">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id7">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id8">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id9">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="id10">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="id11">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id7">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id8">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id9">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id10">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="id11">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="id12">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -414,16 +415,32 @@ You can change the duration of the retention by changing the System Parameter
 <p>If the value is set to 0, the logs are not stored at all.</p>
 <p>Logged data is: request URL and method, parameters, headers, result or error.</p>
 </div>
+<div class="section" id="logs-activation">
+<h2><a class="toc-backref" href="#id4">Logs activation</a></h2>
+<p>You have 2 ways to activate logging:</p>
+<ul class="simple">
+<li>on the service component set <cite>_log_calls_in_db = True</cite></li>
+<li>via configuration</li>
+</ul>
+<p>In the 1st case, calls will be always be logged.</p>
+<p>In the 2nd case you can set <tt class="docutils literal">rest.log.active</tt> param as:</p>
+<pre class="literal-block">
+`collection_name`  # enable for all endpoints of the collection
+`collection_name.usage`  # enable for specific endpoints
+`collection_name.usage.endpoint`  # enable for specific endpoints
+`collection_name*:state`  # enable only for specific state (success, failed)
+</pre>
+</div>
 </div>
 <div class="section" id="changelog">
-<h1><a class="toc-backref" href="#id4">Changelog</a></h1>
+<h1><a class="toc-backref" href="#id5">Changelog</a></h1>
 <div class="section" id="id1">
-<h2><a class="toc-backref" href="#id5">13.0.1.0.0</a></h2>
+<h2><a class="toc-backref" href="#id6">13.0.1.0.0</a></h2>
 <p>First official version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id6">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id7">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/rest-framework/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -431,23 +448,23 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id7">Credits</a></h1>
+<h1><a class="toc-backref" href="#id8">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id8">Authors</a></h2>
+<h2><a class="toc-backref" href="#id9">Authors</a></h2>
 <ul class="simple">
 <li>Camptocamp</li>
 <li>ACSONE</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id9">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id10">Contributors</a></h2>
 <ul class="simple">
 <li>Guewen Baconnier &lt;<a class="reference external" href="mailto:guewen.baconnier&#64;camptocamp.com">guewen.baconnier&#64;camptocamp.com</a>&gt;</li>
 <li>Simone Orsi &lt;<a class="reference external" href="mailto:simahawk&#64;gmail.com">simahawk&#64;gmail.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#id10">Other credits</a></h2>
+<h2><a class="toc-backref" href="#id11">Other credits</a></h2>
 <p><strong>Financial support</strong></p>
 <ul class="simple">
 <li>Cosanum</li>
@@ -456,7 +473,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id11">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id12">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/rest_log/static/description/index.html
+++ b/rest_log/static/description/index.html
@@ -373,7 +373,8 @@ especially in case of errors.</p>
 <p>This module add DB logging for REST requests.
 It also inject in the response the URL of the log entry created.</p>
 <p>NOTE: this feature was implemented initially inside shopfloor app.
-If shopfloor is installed, log records will be copied from its table.</p>
+Up to version 13.0.1.2.1 of this module,
+if shopfloor is installed, log records will be copied from its table.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.

--- a/rest_log/tests/test_db_logging.py
+++ b/rest_log/tests/test_db_logging.py
@@ -105,6 +105,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "request_url": httprequest.url,
             "request_method": httprequest.method,
             "state": "success",
@@ -134,6 +135,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "state": "failed",
             "result": "{}",
             "error": False,
@@ -157,6 +159,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "state": "failed",
             "result": "{}",
             "error": fake_tb,
@@ -184,6 +187,7 @@ class DBLoggingCase(TestDBLoggingBase):
                 self.env, mocked_request, "avg_method", params=params, **kw
             )
         expected = {
+            "collection": self.service._collection,
             "state": "failed",
             "result": "{}",
             "error": fake_tb,

--- a/rest_log/views/rest_log_views.xml
+++ b/rest_log/views/rest_log_views.xml
@@ -5,6 +5,7 @@
         <field name="model">rest.log</field>
         <field name="arch" type="xml">
             <tree decoration-danger="state == 'failed'">
+                <field name="collection" optional="hide" />
                 <field name="create_uid" />
                 <field name="create_date" />
                 <field name="request_method" />
@@ -27,6 +28,7 @@
                 <sheet>
                     <group>
                         <group>
+                            <field name="collection" />
                             <field name="request_url" />
                             <field name="request_method" />
                         </group>
@@ -76,6 +78,7 @@
         <field name="model">rest.log</field>
         <field name="arch" type="xml">
             <search>
+                <field name="collection" />
                 <field name="state" />
                 <field name="request_url" />
                 <field name="request_method" />
@@ -111,6 +114,12 @@
                     domain="[('severity', '=', 'functional')]"
                 />
                 <group expand="0" string="Group By">
+                    <filter
+                        string="Collection"
+                        name="by_collection"
+                        domain="[]"
+                        context="{'group_by': 'collection'}"
+                    />
                     <filter
                         string="User"
                         name="by_user"


### PR DESCRIPTION
Fordward port of PR #147 by @simahawk 

I only add their changes to 14.0.

See atomic commits for details.

Most important change: you can now selectively enable logging by:

`collection_name` # enable for all endpoints of the collection
`collection_name.usage` # enable for specific endpoints
`collection_name.usage.endpoint` # enable for specific endpoints
`collection_name*:state` # enable only for specific state (success, failed)