### PR TITLE
[14.0][IMP] base_rest: New auth method 'public_or_default'

### DIFF
--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -118,7 +118,7 @@ class RestServiceRegistration(models.AbstractModel):
             routing = getattr(method, ROUTING_DECORATOR_ATTR, None)
             if not routing:
                 continue
-            self._apply_default_if_not_set(controller_class, routing, "auth")
+            self._apply_default_auth_if_not_set(controller_class, routing)
             self._apply_default_if_not_set(controller_class, routing, "csrf")
             self._apply_default_if_not_set(controller_class, routing, "save_session")
             self._apply_default_cors_if_not_set(controller_class, routing)
@@ -127,6 +127,17 @@ class RestServiceRegistration(models.AbstractModel):
         default_attr_name = "_default_" + attr_name
         if hasattr(controller_class, default_attr_name) and attr_name not in routing:
             routing[attr_name] = getattr(controller_class, default_attr_name)
+
+    def _apply_default_auth_if_not_set(self, controller_class, routing):
+        default_attr_name = "_default_auth"
+        default_auth = getattr(controller_class, default_attr_name, None)
+        if default_auth:
+            if "auth" in routing:
+                auth = routing["auth"]
+                if auth == "public_or_default":
+                    routing["auth"] = "public_or_" + default_auth
+            else:
+                routing["auth"] = getattr(controller_class, default_attr_name)
 
     def _apply_default_cors_if_not_set(self, controller_class, routing):
         default_attr_name = "_default_cors"

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -135,9 +135,20 @@ class RestServiceRegistration(models.AbstractModel):
             if "auth" in routing:
                 auth = routing["auth"]
                 if auth == "public_or_default":
-                    routing["auth"] = "public_or_" + default_auth
+                    alternative_auth = "public_or_" + default_auth
+                    if getattr(
+                        self.env["ir.http"], "_auth_method_%s" % alternative_auth, None
+                    ):
+                        routing["auth"] = alternative_auth
+                    else:
+                        _logger.debug(
+                            "No %s auth method available: Fallback on %s",
+                            alternative_auth,
+                            default_auth,
+                        )
+                        routing["auth"] = default_auth
             else:
-                routing["auth"] = getattr(controller_class, default_attr_name)
+                routing["auth"] = default_auth
 
     def _apply_default_cors_if_not_set(self, controller_class, routing):
         default_attr_name = "_default_cors"

--- a/base_rest/restapi.py
+++ b/base_rest/restapi.py
@@ -32,7 +32,11 @@ def method(routes, input_param=None, output_param=None, **kw):
                     call to the decorated method, the http handler first call
                     the `to_response` method with this result and then return
                     the result of this call.
-      :param auth: The type of authentication method
+      :param auth: The type of authentication method. A special auth method
+                   named 'public_or_default' can be used. In such a case
+                   when the HTTP route will be generated, the auth method
+                   will be computed from the '_default_auth' property defined
+                   on the controller with 'public_or_' as prefix.
       :param cors: The Access-Control-Allow-Origin cors directive value. When
                    set, this automatically adds OPTIONS to allowed http methods
                    so the Odoo request handler will accept it.

--- a/base_rest/restapi.py
+++ b/base_rest/restapi.py
@@ -37,6 +37,38 @@ def method(routes, input_param=None, output_param=None, **kw):
                    when the HTTP route will be generated, the auth method
                    will be computed from the '_default_auth' property defined
                    on the controller with 'public_or_' as prefix.
+                   The purpose of 'public_or_default' auth method is to provide
+                   a way to specify that a method should work for anonymous users
+                   but can be enhanced when an authenticated user is know.
+                   It implies that when the 'default' auth part of 'public_or_default'
+                   will be replaced by the default_auth specified on the controller
+                   in charge of registering the web services, an auth method with
+                   the same name is defined into odoo to provide such a behavior.
+                   In the following example, the auth method on my ping service
+                   will be `public_or_jwt` since this authentication method is
+                   provided by the auth_jwt addon.
+
+                    .. code-block:: python
+
+                        class PingService(Component):
+                            _inherit = "base.rest.service"
+                            _name = "ping_service"
+                            _usage = "ping"
+                            _collection = "test.api.services"
+
+                            @restapi.method(
+                                [(["/<string:message>""], "GET")],
+                                auth="public_or_auth",
+                            )
+                            def _ping(self, message):
+                                return {"message": message}
+
+
+                        class MyRestController(main.RestController):
+                            _root_path = '/test/'
+                            _collection_name = "test.api.services"
+                            _default_auth = "jwt'
+
       :param cors: The Access-Control-Allow-Origin cors directive value. When
                    set, this automatically adds OPTIONS to allowed http methods
                    so the Odoo request handler will accept it.

--- a/base_rest/tests/test_controller_builder.py
+++ b/base_rest/tests/test_controller_builder.py
@@ -455,6 +455,12 @@ class TestControllerBuilder2(TransactionRestServiceRegistryCase):
             def new_api_method_without(self, _id):
                 return {"name": self.env["res.partner"].browse(_id).name}
 
+            @restapi.method(
+                [(["/new_api_method_with_public_or"], "GET")], auth="public_or_default"
+            )
+            def new_api_method_with_public_or(self, _id):
+                return {"name": self.env["res.partner"].browse(_id).name}
+
             # OLD API method
             def get(self, _id, message):
                 pass
@@ -524,4 +530,8 @@ class TestControllerBuilder2(TransactionRestServiceRegistryCase):
             routes["my_controller_route_without_auth_2"].routing["auth"],
             None,
             "wrong auth for my_controller_route_without_auth_2",
+        )
+        self.assertEqual(
+            routes["get_new_api_method_with_public_or"].routing["auth"],
+            "public_or_my_default_auth",
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # generated from manifests external_dependencies
+apispec
 apispec>=4.0.0
 cerberus
 jsondiff


### PR DESCRIPTION
 A special auth method named 'public_or_default' can be used. In such a case when the HTTP route will be generated, the auth method will be computed from the '_default_auth' property defined on the controller with 'public_or_' as prefix.

ping @sebastienbeau @sbidoul 