### PR TITLE
[14.0] [IMP] allow to use multipart/form-data format

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -122,6 +122,9 @@ class HttpRestRequest(HttpRequest):
                 msg = "Invalid JSON data: %s" % str(e)
                 _logger.info("%s: %s", self.httprequest.path, msg)
                 raise BadRequest(msg)
+        elif self.httprequest.mimetype == "multipart/form-data":
+            # Do not reassign self.params
+            pass
         else:
             # We reparse the query_string in order to handle data structure
             # more information on https://github.com/aventurella/pyquerystring

--- a/base_rest/tests/test_openapi_generator.py
+++ b/base_rest/tests/test_openapi_generator.py
@@ -201,3 +201,129 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
         self.assertListEqual(parameters, default_params)
         responses = path["post"].get("responses", [])
         self.assertIn("999", responses)
+
+    def test_04(self):
+        """Binary and Multipart form-data test case"""
+
+        # pylint: disable=R7980
+        class AttachmentService(Component):
+            _inherit = "base.rest.service"
+            _name = "test.attachment.service"
+            _usage = "attachment"
+            _collection = self._collection_name
+            _description = "Sercice description"
+
+            @restapi.method(
+                routes=[(["/<int:id>/download"], "GET")],
+                output_param=restapi.BinaryData(required=True),
+            )
+            def download(self, _id):
+                """download the attachment"""
+
+            @restapi.method(
+                routes=[(["/create"], "POST")],
+                input_param=restapi.MultipartFormData(
+                    {
+                        "file": restapi.BinaryData(
+                            mediatypes=["image/png", "image/jpeg"]
+                        ),
+                        "params": restapi.CerberusValidator("_get_attachment_schema"),
+                    }
+                ),
+                output_param=restapi.CerberusValidator("_get_attachment_schema"),
+            )
+            # pylint: disable=W8106
+            def create(self, file, params):
+                """create the attachment"""
+
+            def _get_attachment_schema(self):
+                return {"name": {"type": "string", "required": True}}
+
+        self._build_services(self, AttachmentService)
+        service = self._get_service_component(self, "attachment")
+        openapi = service.to_openapi()
+        paths = openapi["paths"]
+        # The paths must contains 2 entries (1 by routes)
+        self.assertSetEqual({"/{id}/download", "/create"}, set(openapi["paths"]))
+        path_download = paths["/{id}/download"]
+        resp_download = None
+        for item in path_download["get"]["responses"].items():
+            if item[0] == "200":
+                resp_download = item[1]
+        self.assertTrue(resp_download)
+        self.assertDictEqual(
+            resp_download,
+            {
+                "content": {
+                    "*/*": {
+                        "schema": {
+                            "type": "string",
+                            "format": "binary",
+                            "required": True,
+                        }
+                    }
+                }
+            },
+        )
+        # The path contains parameters
+        self.assertDictEqual(
+            path_download.get("parameters", [{}])[0],
+            {
+                "in": "path",
+                "name": "id",
+                "required": True,
+                "schema": {"type": "integer", "format": "int32"},
+            },
+        )
+        path_create = paths["/create"]
+        resp_create = None
+        for item in path_create["post"]["responses"].items():
+            if item[0] == "200":
+                resp_create = item[1]
+        self.assertTrue(resp_create)
+        self.assertDictEqual(
+            resp_create,
+            {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "properties": {"name": {"type": "string"}},
+                            "required": ["name"],
+                            "type": "object",
+                        }
+                    }
+                }
+            },
+        )
+        request_create = path_create["post"]["requestBody"]
+        self.assertDictEqual(
+            request_create,
+            {
+                "content": {
+                    "multipart/form-data": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "string",
+                                    "format": "binary",
+                                    "required": False,
+                                },
+                                "params": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                        },
+                                    },
+                                    "required": ["name"],
+                                },
+                            },
+                            "encoding": {
+                                "file": {"contentType": "image/png, image/jpeg"}
+                            },
+                        }
+                    }
+                }
+            },
+        )

--- a/base_rest_datamodel/restapi.py
+++ b/base_rest_datamodel/restapi.py
@@ -63,7 +63,9 @@ class Datamodel(restapi.RestMethodParam):
     def to_openapi_requestbody(self, service, spec):
         return {
             "content": {
-                "application/json": {"schema": self.to_json_schema(service, "input")}
+                "application/json": {
+                    "schema": self.to_json_schema(service, spec, "input")
+                }
             }
         }
 
@@ -72,13 +74,13 @@ class Datamodel(restapi.RestMethodParam):
             "200": {
                 "content": {
                     "application/json": {
-                        "schema": self.to_json_schema(service, "output")
+                        "schema": self.to_json_schema(service, spec, "output")
                     }
                 }
             }
         }
 
-    def to_json_schema(self, service, direction):
+    def to_json_schema(self, service, spec, direction):
         converter = self._get_converter()
         schema = self._get_schema(service)
         return converter.resolve_nested_schema(schema)

--- a/base_rest_pydantic/restapi.py
+++ b/base_rest_pydantic/restapi.py
@@ -86,16 +86,26 @@ class PydanticModel(restapi.RestMethodParam):
     # allows to add the definition of a schema only once into the specs
     # and use a reference to the schema into the parameters
     def to_openapi_requestbody(self, service, spec):
-        return {"content": {"application/json": {"schema": self.to_json_schema(spec)}}}
+        return {
+            "content": {
+                "application/json": {
+                    "schema": self.to_json_schema(service, spec, "input")
+                }
+            }
+        }
 
     def to_openapi_responses(self, service, spec):
         return {
             "200": {
-                "content": {"application/json": {"schema": self.to_json_schema(spec)}}
+                "content": {
+                    "application/json": {
+                        "schema": self.to_json_schema(service, spec, "output")
+                    }
+                }
             }
         }
 
-    def to_json_schema(self, spec):
+    def to_json_schema(self, service, spec, direction):
         schema = self._model_cls.schema()
         schema_name = schema["title"]
         if schema_name not in spec.components.schemas:
@@ -170,17 +180,27 @@ class PydanticModelList(PydanticModel):
     # allows to add the definition of a schema only once into the specs
     # and use a reference to the schema into the parameters
     def to_openapi_requestbody(self, service, spec):
-        return {"content": {"application/json": {"schema": self.to_json_schema(spec)}}}
+        return {
+            "content": {
+                "application/json": {
+                    "schema": self.to_json_schema(service, spec, "input")
+                }
+            }
+        }
 
     def to_openapi_responses(self, service, spec):
         return {
             "200": {
-                "content": {"application/json": {"schema": self.to_json_schema(spec)}}
+                "content": {
+                    "application/json": {
+                        "schema": self.to_json_schema(service, spec, "output")
+                    }
+                }
             }
         }
 
-    def to_json_schema(self, spec):
-        json_schema = super().to_json_schema(spec)
+    def to_json_schema(self, service, spec, direction):
+        json_schema = super().to_json_schema(service, spec, direction)
         json_schema = {"type": "array", "items": json_schema}
         if self._min_items is not None:
             json_schema["minItems"] = self._min_items


### PR DESCRIPTION
This allows to send files while also providing additional info (eg. attachment name,  res_id and res_model)

Here is an implementation: https://github.com/OCA/helpdesk/pull/270