### PR TITLE
[14.0][FIX] base_rest: path parameters must be named the same as parameters…

### DIFF
--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -285,32 +285,32 @@ class RestApiMethodTransformer(object):
         id_in_path_required = "_id" in signature.parameters
         path = "/{}".format(method_name)
         if id_in_path_required:
-            path = "/<int:id>" + path
+            path = "/<int:_id>" + path
         if method_name in ("get", "search"):
             paths = [path]
             path = "/"
             if id_in_path_required:
-                path = "/<int:id>"
+                path = "/<int:_id>"
             paths.append(path)
             return [(paths, "GET")]
         elif method_name == "delete":
             routes = [(path, "POST")]
             path = "/"
             if id_in_path_required:
-                path = "/<int:id>"
+                path = "/<int:_id>"
             routes.append((path, "DELETE"))
         elif method_name == "update":
             paths = [path]
             path = "/"
             if id_in_path_required:
-                path = "/<int:id>"
+                path = "/<int:_id>"
             paths.append(path)
             routes = [(paths, "POST"), (path, "PUT")]
         elif method_name == "create":
             paths = [path]
             path = "/"
             if id_in_path_required:
-                path = "/<int:id>"
+                path = "/<int:_id>"
             paths.append(path)
             routes = [(paths, "POST")]
         else:

--- a/base_rest/tests/test_controller_builder.py
+++ b/base_rest/tests/test_controller_builder.py
@@ -106,8 +106,8 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "cors": None,
                 "csrf": False,
                 "routes": [
-                    "/test_controller/ping/<int:id>/get",
-                    "/test_controller/ping/<int:id>",
+                    "/test_controller/ping/<int:_id>/get",
+                    "/test_controller/ping/<int:_id>",
                 ],
                 "save_session": True,
             },
@@ -135,8 +135,8 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "cors": None,
                 "csrf": False,
                 "routes": [
-                    "/test_controller/ping/<int:id>/update",
-                    "/test_controller/ping/<int:id>",
+                    "/test_controller/ping/<int:_id>/update",
+                    "/test_controller/ping/<int:_id>",
                 ],
                 "save_session": True,
             },
@@ -150,7 +150,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "public",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/ping/<int:id>"],
+                "routes": ["/test_controller/ping/<int:_id>"],
                 "save_session": True,
             },
         )
@@ -176,7 +176,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "public",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/ping/<int:id>/delete"],
+                "routes": ["/test_controller/ping/<int:_id>/delete"],
                 "save_session": True,
             },
         )
@@ -189,7 +189,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "public",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/ping/<int:id>"],
+                "routes": ["/test_controller/ping/<int:_id>"],
                 "save_session": True,
             },
         )
@@ -215,7 +215,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "public",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/ping/<int:id>/my_instance_method"],
+                "routes": ["/test_controller/ping/<int:_id>/my_instance_method"],
                 "save_session": True,
             },
         )
@@ -237,7 +237,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
             _description = "test"
 
             @restapi.method(
-                [(["/<int:id>/get", "/<int:id>"], "GET")],
+                [(["/<int:_id>/get", "/<int:_id>"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )
@@ -245,7 +245,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 return {"name": self.env["res.partner"].browse(_id).name}
 
             @restapi.method(
-                [(["/<int:id>/get_name"], "GET")],
+                [(["/<int:_id>/get_name"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )
@@ -253,7 +253,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 return {"name": self.env["res.partner"].browse(_id).name}
 
             @restapi.method(
-                [(["/<int:id>/change_name"], "POST")],
+                [(["/<int:_id>/change_name"], "POST")],
                 input_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="user",
             )
@@ -283,8 +283,8 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "cors": None,
                 "csrf": False,
                 "routes": [
-                    "/test_controller/partner/<int:id>/get",
-                    "/test_controller/partner/<int:id>",
+                    "/test_controller/partner/<int:_id>/get",
+                    "/test_controller/partner/<int:_id>",
                 ],
                 "save_session": True,
             },
@@ -298,7 +298,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "public",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/partner/<int:id>/get_name"],
+                "routes": ["/test_controller/partner/<int:_id>/get_name"],
                 "save_session": True,
             },
         )
@@ -311,7 +311,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "user",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/partner/<int:id>/change_name"],
+                "routes": ["/test_controller/partner/<int:_id>/change_name"],
                 "save_session": True,
             },
         )
@@ -328,7 +328,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
             _description = "test"
 
             @restapi.method(
-                [(["/<int:id>/get", "/<int:id>"], "GET")],
+                [(["/<int:_id>/get", "/<int:_id>"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )
@@ -342,7 +342,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
             _inherit = "test.partner.service"
 
             @restapi.method(
-                [(["/<int:id>/get_name"], "GET")],
+                [(["/<int:_id>/get_name"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )
@@ -350,7 +350,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 return {"name": self.env["res.partner"].browse(_id).name}
 
             @restapi.method(
-                [(["/<int:id>/change_name"], "POST")],
+                [(["/<int:_id>/change_name"], "POST")],
                 input_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="user",
             )
@@ -377,8 +377,8 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "cors": None,
                 "csrf": False,
                 "routes": [
-                    "/test_controller/partner/<int:id>/get",
-                    "/test_controller/partner/<int:id>",
+                    "/test_controller/partner/<int:_id>/get",
+                    "/test_controller/partner/<int:_id>",
                 ],
                 "save_session": True,
             },
@@ -392,7 +392,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "public",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/partner/<int:id>/get_name"],
+                "routes": ["/test_controller/partner/<int:_id>/get_name"],
                 "save_session": True,
             },
         )
@@ -405,7 +405,7 @@ class TestControllerBuilder(TransactionRestServiceRegistryCase):
                 "auth": "user",
                 "cors": None,
                 "csrf": False,
-                "routes": ["/test_controller/partner/<int:id>/change_name"],
+                "routes": ["/test_controller/partner/<int:_id>/change_name"],
                 "save_session": True,
             },
         )

--- a/base_rest/tests/test_openapi_generator.py
+++ b/base_rest/tests/test_openapi_generator.py
@@ -22,7 +22,7 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
             _description = "Sercice description"
 
             @restapi.method(
-                [(["/<int:id>/get", "/<int:id>"], "GET")],
+                [(["/<int:_id>/get", "/<int:_id>"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )
@@ -49,9 +49,9 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
 
         paths = openapi["paths"]
         # The paths must contains 2 entries (1 by routes)
-        self.assertSetEqual({"/{id}/get", "/{id}"}, set(openapi["paths"]))
+        self.assertSetEqual({"/{_id}/get", "/{_id}"}, set(openapi["paths"]))
 
-        for p in ["/{id}/get", "/{id}"]:
+        for p in ["/{_id}/get", "/{_id}"]:
             path = paths[p]
             # The method for the paths is get
             self.assertIn("get", path)
@@ -85,7 +85,7 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
                 path.get("parameters", [{}])[0],
                 {
                     "in": "path",
-                    "name": "id",
+                    "name": "_id",
                     "required": True,
                     "schema": {"type": "integer", "format": "int32"},
                 },
@@ -107,7 +107,7 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
             _description = "Sercice description"
 
             @restapi.method(
-                [(["/<int:id>/update_name/<string:name>"], "POST")], auth="public"
+                [(["/<int:_id>/update_name/<string:name>"], "POST")], auth="public"
             )
             def update_name(self, _id, _name):
                 """update_name"""
@@ -117,15 +117,15 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
         openapi = service.to_openapi()
         self.assertTrue(openapi)
         paths = openapi["paths"]
-        self.assertIn("/{id}/update_name/{name}", paths)
-        path = paths["/{id}/update_name/{name}"]
+        self.assertIn("/{_id}/update_name/{name}", paths)
+        path = paths["/{_id}/update_name/{name}"]
         self.assertIn("post", path)
         parameters = path["parameters"]
         self.assertEqual(2, len(parameters))
         name_param = {}
         id_param = {}
         for p in parameters:
-            if p["name"] == "id":
+            if p["name"] == "_id":
                 id_param = p
             else:
                 name_param = p
@@ -142,7 +142,7 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
             id_param,
             {
                 "in": "path",
-                "name": "id",
+                "name": "_id",
                 "required": True,
                 "schema": {"type": "integer", "format": "int32"},
             },
@@ -175,7 +175,7 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
             _description = "Sercice description"
 
             @restapi.method(
-                [(["/<int:id>/update_name/<string:name>"], "POST")], auth="public"
+                [(["/<int:_id>/update_name/<string:name>"], "POST")], auth="public"
             )
             def update_name(self, _id, _name):
                 """update_name"""
@@ -194,8 +194,8 @@ class TestOpenAPIGenerator(TransactionRestServiceRegistryCase):
         service = self._get_service_component(self, "partner")
         openapi = service.to_openapi()
         paths = openapi["paths"]
-        self.assertIn("/{id}/update_name/{name}", paths)
-        path = paths["/{id}/update_name/{name}"]
+        self.assertIn("/{_id}/update_name/{name}", paths)
+        path = paths["/{_id}/update_name/{name}"]
         self.assertIn("post", path)
         parameters = path["post"].get("parameters", [])
         self.assertListEqual(parameters, default_params)

--- a/base_rest/tests/test_service_context_provider.py
+++ b/base_rest/tests/test_service_context_provider.py
@@ -29,7 +29,7 @@ class TestServiceContextProvider(TransactionRestServiceRegistryCase):
             _description = "test"
 
             @restapi.method(
-                [(["/<int:id>/get", "/<int:id>"], "GET")],
+                [(["/<int:_id>/get", "/<int:_id>"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )
@@ -73,7 +73,7 @@ class TestServiceContextProvider(TransactionRestServiceRegistryCase):
             _description = "test"
 
             @restapi.method(
-                [(["/<int:id>/get", "/<int:id>"], "GET")],
+                [(["/<int:_id>/get", "/<int:_id>"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )
@@ -119,7 +119,7 @@ class TestServiceContextProvider(TransactionRestServiceRegistryCase):
             _description = "test"
 
             @restapi.method(
-                [(["/<int:id>/get", "/<int:id>"], "GET")],
+                [(["/<int:_id>/get", "/<int:_id>"], "GET")],
                 output_param=restapi.CerberusValidator("_get_partner_schema"),
                 auth="public",
             )

--- a/base_rest_demo/services/partner_new_api_services.py
+++ b/base_rest_demo/services/partner_new_api_services.py
@@ -16,7 +16,7 @@ class PartnerNewApiService(Component):
     """
 
     @restapi.method(
-        [(["/<int:id>/get", "/<int:id>"], "GET")],
+        [(["/<int:_id>/get", "/<int:_id>"], "GET")],
         output_param=Datamodel("partner.info"),
         auth="public",
     )

--- a/base_rest_demo/tests/data/partner_api.json
+++ b/base_rest_demo/tests/data/partner_api.json
@@ -10,7 +10,7 @@
     }
   ],
   "paths": {
-    "/{id}/archive": {
+    "/{_id}/archive": {
       "post": {
         "summary": "\nArchive the given partner. This method is an empty method, IOW it\ndon't update the partner. This method is part of the demo data to\nillustrate that historically it's not mandatory to defined a schema\ndescribing the content of the response returned by a method.\nThis kind of definition is DEPRECATED and will no more supported in\nthe future.\n:param _id:\n:param params:\n:return:\n",
         "requestBody": {
@@ -47,7 +47,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",
@@ -464,7 +464,7 @@
         ]
       }
     },
-    "/{id}/get": {
+    "/{_id}/get": {
       "get": {
         "summary": "\nGet partner's informations\n",
         "responses": {
@@ -554,7 +554,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",
@@ -563,7 +563,7 @@
         }
       ]
     },
-    "/{id}": {
+    "/{_id}": {
       "get": {
         "summary": "\nGet partner's informations\n",
         "responses": {
@@ -653,7 +653,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",
@@ -1068,7 +1068,7 @@
         ]
       }
     },
-    "/{id}/update": {
+    "/{_id}/update": {
       "post": {
         "summary": "\nUpdate partner informations\n",
         "requestBody": {
@@ -1219,7 +1219,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",

--- a/base_rest_demo/tests/data/partner_image_api.json
+++ b/base_rest_demo/tests/data/partner_image_api.json
@@ -10,7 +10,7 @@
     }
   ],
   "paths": {
-    "/{id}/get": {
+    "/{_id}/get": {
       "get": {
         "summary": "\nGet partner's image\n",
         "parameters": [
@@ -49,7 +49,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",
@@ -58,7 +58,7 @@
         }
       ]
     },
-    "/{id}": {
+    "/{_id}": {
       "get": {
         "summary": "\nGet partner's image\n",
         "parameters": [
@@ -97,7 +97,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",

--- a/base_rest_demo/tests/data/ping_api.json
+++ b/base_rest_demo/tests/data/ping_api.json
@@ -195,7 +195,7 @@
         }
       }
     },
-    "/{id}/delete": {
+    "/{_id}/delete": {
       "post": {
         "summary": "\nDelete method description ...\n",
         "requestBody": {
@@ -242,7 +242,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",
@@ -251,7 +251,7 @@
         }
       ]
     },
-    "/{id}": {
+    "/{_id}": {
       "delete": {
         "summary": "\nDelete method description ...\n",
         "requestBody": {
@@ -298,7 +298,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",
@@ -448,7 +448,7 @@
         }
       }
     },
-    "/{id}/get": {
+    "/{_id}/get": {
       "get": {
         "summary": "\nThis method is used to get the information of the object specified\nby Id.\n",
         "parameters": [
@@ -499,7 +499,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",
@@ -597,7 +597,7 @@
         }
       }
     },
-    "/{id}/update": {
+    "/{_id}/update": {
       "post": {
         "summary": "\nUpdate method description ...\n",
         "requestBody": {
@@ -648,7 +648,7 @@
       "parameters": [
         {
           "in": "path",
-          "name": "id",
+          "name": "_id",
           "required": true,
           "schema": {
             "type": "integer",

--- a/rest_log/tests/common.py
+++ b/rest_log/tests/common.py
@@ -32,7 +32,7 @@ class TestDBLoggingBase(SavepointRestServiceRegistryCase):
             _log_calls_in_db = True
 
             @restapi.method(
-                [(["/<int:id>/get", "/<int:id>"], "GET")],
+                [(["/<int:_id>/get", "/<int:_id>"], "GET")],
                 output_param=restapi.CerberusValidator("_get_out_schema"),
                 auth="public",
             )


### PR DESCRIPTION
… into the method signature