### PR TITLE
[14.0] [FIX] test: Remove merged PR OCA/connector/pull/393

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,0 @@
-odoo14-addon-component @ git+https://github.com/OCA/connector@refs/pull/393/head#subdirectory=setup/component


### PR DESCRIPTION
PR https://github.com/OCA/connector/pull/393 has been merged so the test requirement is not needed any more.