### PR TITLE
base_rest: decouple rest route registration

### DIFF
--- a/base_rest/core.py
+++ b/base_rest/core.py
@@ -10,6 +10,8 @@ class RestServicesDatabases(dict):
 
 _rest_services_databases = RestServicesDatabases()
 
+_rest_services_routes = collections.defaultdict(set)
+
 _rest_controllers_per_module = collections.defaultdict(list)
 
 

--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -33,7 +33,7 @@ from odoo.http import HttpRequest, Root, SessionExpiredException, request
 from odoo.tools import ustr
 from odoo.tools.config import config
 
-from .core import _rest_services_databases
+from .core import _rest_services_routes
 
 _logger = logging.getLogger(__name__)
 
@@ -217,11 +217,10 @@ def get_request(self, httprequest):
         # so we enforce its loading here to make sure that
         # _rest_services_databases is not empty
         odoo.registry(db)
-        service_registry = _rest_services_databases.get(db)
-        if service_registry:
-            for root_path in service_registry:
-                if httprequest.path.startswith(root_path):
-                    return HttpRestRequest(httprequest)
+        rest_routes = _rest_services_routes.get(db, [])
+        for root_path in rest_routes:
+            if httprequest.path.startswith(root_path):
+                return HttpRestRequest(httprequest)
     return ori_get_request(self, httprequest)
 
 

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -27,6 +27,7 @@ from ..core import (
     RestServicesRegistry,
     _rest_controllers_per_module,
     _rest_services_databases,
+    _rest_services_routes,
 )
 from ..tools import _inspect_methods
 
@@ -222,6 +223,7 @@ class RestServiceRegistration(models.AbstractModel):
                     else None
                 )
                 services_registry[controller_def["root_path"]] = controller_def
+                self._register_rest_route(controller_def["root_path"])
                 if (
                     current_controller
                     and current_controller != controller_def["controller_class"]
@@ -239,6 +241,13 @@ class RestServiceRegistration(models.AbstractModel):
         services_registry = RestServicesRegistry()
         _rest_services_databases[self.env.cr.dbname] = services_registry
         return services_registry
+
+    def _register_rest_route(self, route_path):
+        """Register given route path to be handles as RestRequest.
+
+        See base_rest.http.get_request.
+        """
+        _rest_services_routes[self.env.cr.dbname].add(route_path)
 
 
 class RestApiMethodTransformer(object):


### PR DESCRIPTION
REST requests are detected by checking the services registry.
This limits the possibility to register additional routes
as to be handled with the HttpRestRequest class.

Now the route registration is decoupled allowing 3rd parties
to register their own routes without loading them from a controller.