### PR TITLE
[IMP] graphql_base: add hook for context

### DIFF
--- a/graphql_base/controllers/main.py
+++ b/graphql_base/controllers/main.py
@@ -48,9 +48,13 @@ class GraphQLControllerMixin(object):
             return http.request.params
         return {}
 
+    def _make_context(self, schema, data):
+        return {"env": http.request.env}
+
     def _process_request(self, schema, data):
         try:
             request = http.request.httprequest
+            context = self._make_context(schema, data)
             execution_results, all_params = run_http_query(
                 schema,
                 request.method.lower(),
@@ -58,7 +62,7 @@ class GraphQLControllerMixin(object):
                 query_data=request.args,
                 batch_enabled=False,
                 catch=False,
-                context={"env": http.request.env},
+                context=context,
             )
             result, status_code = encode_execution_results(
                 execution_results,


### PR DESCRIPTION
Add hook to allow injection of more information in context.

While in my case I use http.request.parameter I added `schema` and `data` for convenience and to avoid signature issue in the future.