### PR TITLE
[11.0][FIX] base_rest: correct external-dependency

### DIFF
--- a/base_rest/__manifest__.py
+++ b/base_rest/__manifest__.py
@@ -20,6 +20,6 @@
     ],
     "demo": [],
     "external_dependencies": {
-        "python": ["cerberus", "pyquerystring", "accept_language"]
+        "python": ["cerberus", "pyquerystring", "parse-accept-language"]
     },
 }


### PR DESCRIPTION
Use correct name, the one that is in requirements.