### PR TITLE
[13.0][FIX] base_rest: correct external-dependency

### DIFF
--- a/base_rest/__manifest__.py
+++ b/base_rest/__manifest__.py
@@ -20,7 +20,7 @@
     ],
     "demo": [],
     "external_dependencies": {
-        "python": ["cerberus", "pyquerystring", "accept_language", "apispec"]
+        "python": ["cerberus", "pyquerystring", "parse-accept-language", "apispec"]
     },
     "installable": True,
 }

--- a/setup/base_rest/setup.py
+++ b/setup/base_rest/setup.py
@@ -5,7 +5,6 @@ setuptools.setup(
     odoo_addon={
         'external_dependencies_override': {
             'python': {
-                'accept_language': 'parse-accept-language',
                 'apispec': 'apispec>=4.0.0'
             },
         },


### PR DESCRIPTION
Use correct name, the one that is in requirements.