### PR TITLE
[14.0][FIX] rest_log: inject log entry URL only for dict response

### DIFF
--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -68,7 +68,7 @@ class BaseRESTService(AbstractComponent):
         log_entry = self._log_call_in_db(
             self.env, request, method_name, *args, params=params, result=result
         )
-        if log_entry:
+        if log_entry and isinstance(result, dict):
             log_entry_url = self._get_log_entry_url(log_entry)
             result["log_entry_url"] = log_entry_url
         return result


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/OCA/rest-framework/pull/147/commits/cb4dfad3eab4803d1183e1b8d64c2cbcea6f8cda

Original fix: https://github.com/OCA/rest-framework/commit/c607a423a27a1d4a86a88952f4537599c7dff849