### PR TITLE
fix args order mistake when the path has multi path arguments,

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -123,7 +123,6 @@ class HttpRestRequest(HttpRequest):
             except ValueError as e:
                 msg = "Invalid JSON data: %s" % str(e)
                 _logger.info("%s: %s", self.httprequest.path, msg)
-                raise BadRequest(msg)
         else:
             # We reparse the query_string in order to handle data structure
             # more information on https://github.com/aventurella/pyquerystring

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -333,7 +333,7 @@ class RestApiServiceControllerGenerator(object):
                         method_name=method_name,
                         service_name=self._service_name,
                         service_method_name=name,
-                        args=", ".join(rule.arguments),
+                        args=", ".join([c[1] for c in rule._trace if c[0]]),
                     )
                 else:
                     method = METHOD_TMPL.format(


### PR DESCRIPTION
eg.,rule with "/path/<string:in1>/<string:in2>" ,
path with /path/1/2,
will get in2=1, in1=2 with mistake sometimes
becuase the rule.arguments is type of set which was not ordered,
after fix, will always got in1=1, in2=2