### PR TITLE
base_rest: decorate service endpoints always

### DIFF
--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -56,6 +56,14 @@ class BaseRestService(AbstractComponent):
     _description = None  # description included into the openapi doc
     _is_rest_service_component = True  # marker to retrieve REST components
 
+    def __init__(self, work_context):
+        super().__init__(work_context)
+        self._auto_decorate_endpoints()
+
+    def _auto_decorate_endpoints(self):
+        """Automatically decorate non decorated public methods."""
+        self.env["rest.service.registration"]._prepare_non_decorated_endpoints(self)
+
     def _prepare_extra_log(self, func, params, secure_params, res):
         httprequest = request.httprequest
         headers = dict(httprequest.headers)

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -73,7 +73,6 @@ class RestServiceRegistration(models.AbstractModel):
     def _build_controllers_routes(self, services_registry):
         for controller_def in services_registry.values():
             for service in self._get_services(controller_def["collection_name"]):
-                self._prepare_non_decorated_endpoints(service)
                 self._build_controller(service, controller_def)
 
     def _prepare_non_decorated_endpoints(self, service):


### PR DESCRIPTION
Decorate services' methods when the component is initialized.
This way, the state of the component is the same no matter where you get it from.

@lmignon what do you think?

Note that I left it in `rest.service.registration` but it can be moved in utils or to a specific component.