### PR TITLE
Include graphql_base in v15 branch

### DIFF
--- a/graphql_base/__manifest__.py
+++ b/graphql_base/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Graphql Base",
     "summary": """
         Base GraphQL/GraphiQL controller""",
-    "version": "13.0.1.0.0",
+    "version": "15.0.1.0.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",
@@ -14,5 +14,5 @@
     "external_dependencies": {"python": ["graphene", "graphql-server-core"]},
     "development_status": "Beta",
     "maintainers": ["sbidoul"],
-    "installable": False,
+    "installable": True,
 }


### PR DESCRIPTION
It works for me flawlessly in v15 with python package versions:
graphene==2.1.9
graphql-server-core==2.0.0