### PR TITLE
[13.0] base_rest: fix args order mistake when the path has multi path arguments,

### DIFF
--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -333,7 +333,7 @@ class RestApiServiceControllerGenerator(object):
                         method_name=method_name,
                         service_name=self._service_name,
                         service_method_name=name,
-                        args=", ".join(rule.arguments),
+                        args=", ".join([c[1] for c in rule._trace if c[0]]),
                     )
                 else:
                     method = METHOD_TMPL.format(

--- a/graphql_demo/tests/test_controller.py
+++ b/graphql_demo/tests/test_controller.py
@@ -6,13 +6,14 @@ import json
 from werkzeug.urls import url_encode
 
 from odoo.tests import HttpCase
-from odoo.tests.common import HOST, PORT
-from odoo.tools import mute_logger
+from odoo.tests.common import HOST
+from odoo.tools import config, mute_logger
 
 
 class TestController(HttpCase):
     def url_open_json(self, url, json):
-        return self.opener.post("http://{}:{}{}".format(HOST, PORT, url), json=json)
+        port = config["http_port"]
+        return self.opener.post("http://{}:{}{}".format(HOST, port, url), json=json)
 
     def _check_all_partners(self, all_partners, companies_only=False):
         domain = []


### PR DESCRIPTION
eg.,rule with "/path/<string:in1>/<string:in2>" ,
path with /path/1/2,
will get in2=1, in1=2 with mistake sometimes
becuase the rule.arguments is type of set which was not ordered,
after fix, will always got in1=1, in2=2

backport of #264 from 14.0