### PR TITLE
[15.0][FIX] base_rest: `swagger_ui.js` is (sometimes) loaded first, causing crashes

### DIFF
--- a/base_rest/__manifest__.py
+++ b/base_rest/__manifest__.py
@@ -12,7 +12,7 @@
     "author": "ACSONE SA/NV, " "Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],
     "website": "https://github.com/OCA/rest-framework",
-    "depends": ["component"],
+    "depends": ["component", "web"],
     "data": [
         "views/openapi_template.xml",
         "views/base_rest_view.xml",


### PR DESCRIPTION
Using `base_rest` in Odoo 15 results sometimes in UI crashes (web client not loading) because `swagger_ui.js` is loaded before anything else. This is fixed by adding an explicit dependency to `web`. 

The exact circumstances under which `swagger_ui.js` is loaded first is not completely clear -- usually when other modules depending on it are loaded, even when such modules don't contain JS themselves. The addition of this dependency seems to fix the issue in all cases.