### PR TITLE
[FIX] model-serializer: `load_only` fields are ignored during loading

### DIFF
--- a/model_serializer/core.py
+++ b/model_serializer/core.py
@@ -154,7 +154,9 @@ class ModelSerializer(Datamodel, metaclass=MetaModelSerializer):
     def _get_partial_fields(self):
         """Return the list of fields actually used to instantiate `self`"""
         res = []
-        received_keys = self.dump(many=False).keys()
+        received_keys = set(self.__schema__._declared_fields) - set(
+            self.__missing_fields__
+        )
         actual_field_names = {
             field.data_key: name
             for name, field in self.__schema__._declared_fields.items()
@@ -177,7 +179,8 @@ class ModelSerializer(Datamodel, metaclass=MetaModelSerializer):
                         res.append((1, rec_id, dic))
                     else:
                         res.append((4, rec_id))
-                res.append((0, 0, dic))
+                else:
+                    res.append((0, 0, dic))
             return res
 
         model_name = model or self._model


### PR DESCRIPTION
This is due to the usage of `dump()` to filter off the fields that are missing from the partial datamodel (to differentiate them from null values).