### PR TITLE
[FIX] base_rest: Patch from the first request

### DIFF
--- a/base_rest/controllers/main.py
+++ b/base_rest/controllers/main.py
@@ -6,7 +6,8 @@ from contextlib import contextmanager
 
 from werkzeug.exceptions import BadRequest
 
-from odoo.http import Controller, ControllerType, Response, request
+from odoo.http import Controller, ControllerType, Response, request, \
+    controllers_per_module
 
 from odoo.addons.component.core import WorkContext, _get_addon_name
 
@@ -36,6 +37,13 @@ class RestControllerType(ControllerType):
             # our RestConrtroller must be a direct child of Controller
             bases += (Controller,)
         super(RestControllerType, cls).__init__(name, bases, attrs)
+        # The generic controller should not be registered as a controller
+        # even if it inherits from Controller
+        base_rest_controllers = controllers_per_module['base_rest']
+        name_class = ("%s.%s" % (cls.__module__, 'RestController'), cls)
+        if name_class in base_rest_controllers:
+            base_rest_controllers.remove(name_class)
+
         if "RestController" not in globals() or not any(
             issubclass(b, RestController) for b in bases
         ):

--- a/base_rest/readme/CONFIGURE.rst
+++ b/base_rest/readme/CONFIGURE.rst
@@ -1,3 +1,9 @@
+Load this module at Odoo startup including in your server config file:
+
+.. code-block:: cfg
+
+    server_wide_modules=base,web,base_rest
+
 If an error occurs when calling a method of a service (ie missing parameter,
 ..) the system returns only a general description of the problem without
 details. This is done on purpose to ensure maximum opacity on implementation


### PR DESCRIPTION
This is to help users solving issue https://github.com/OCA/rest-framework/issues/154.

I have reproduced this issue locally with the steps:

1. Install `base_rest_demo`
2. Open the REST api app, ensure this is the only window opened that is contacting Odoo
3. Choose the new api partner services and do a search -> this works fine
4. Reboot odoo, without closing the window
5. Choose the new api partner services and do a search -> this raises

    >  File "/home/simone/work/odoo12/rest-framework/base_rest/controllers/main.py", line 95, in make_response
    return request.make_json_response(data)
  File "/home/simone/work/odoo12/venv/lib/python3.6/site-packages/werkzeug/local.py", line 343, in __getattr__
    return getattr(self._get_current_object(), name)
AttributeError: 'HttpRequest' object has no attribute 'make_json_response' - - -
6. Choose the new api partner services and do a search -> this works fine again

The configuration patch has been suggested in:
>This patch work like a charm ...! 
>
>You need to load base_rest at odoo start. Because, this enforce the loading of the registry in the get_request().
>So we can use base_rest as server_wide_module()
>
>Here odoo conf example :
>```
>[options]
># ex: for Odoo 14.0
>server_wide_modules=base,web,base_rest
># ...
>
_Originally posted by @dinuth-perera in https://github.com/OCA/rest-framework/issues/154#issuecomment-1053658207_