### PR TITLE
[FIX] 14.0 pydantic: generate schema using field name

### DIFF
--- a/base_rest_demo/tests/data/partner_pydantic_api.json
+++ b/base_rest_demo/tests/data/partner_pydantic_api.json
@@ -248,7 +248,7 @@
             "title": "Street2",
             "type": "string"
           },
-          "zip": {
+          "zip_code": {
             "title": "Zip",
             "type": "string"
           },
@@ -260,10 +260,10 @@
             "title": "Phone",
             "type": "string"
           },
-          "state_id": {
+          "state": {
             "$ref": "#/components/schemas/StateInfo"
           },
-          "country_id": {
+          "country": {
             "$ref": "#/components/schemas/CountryInfo"
           },
           "is_company": {
@@ -271,7 +271,7 @@
             "type": "boolean"
           }
         },
-        "required": ["id", "name", "street", "zip", "city", "state_id", "country_id"],
+        "required": ["id", "name", "street", "zip_code", "city", "state", "country"],
         "definitions": {
           "StateInfo": {
             "title": "StateInfo",

--- a/base_rest_pydantic/restapi.py
+++ b/base_rest_pydantic/restapi.py
@@ -106,7 +106,7 @@ class PydanticModel(restapi.RestMethodParam):
         }
 
     def to_json_schema(self, service, spec, direction):
-        schema = self._model_cls.schema()
+        schema = self._model_cls.schema(by_alias=False)
         schema_name = schema["title"]
         if schema_name not in spec.components.schemas:
             definitions = schema.get("definitions", {})


### PR DESCRIPTION
ref: https://pydantic-docs.helpmanual.io/usage/schema/ 

> The schema is generated by default using aliases as keys, but it can be generated using model property names instead by calling MainModel.schema/schema_json(by_alias=False).


Before:

generated schema uses aliases (odoo's internal naming) to name fields.

The schema does not correspond to what's effectively returned.

![Capture d’écran du 2022-08-10 14-44-14](https://user-images.githubusercontent.com/8819682/183906213-17d05329-b154-465a-8cc4-213307a2d973.png)

After:

generated schema uses the field's name, masking odoo's internal naming.

The schema corresponds to what's effectively returned.

![Capture d’écran du 2022-08-10 14-44-38](https://user-images.githubusercontent.com/8819682/183906236-4442e4c3-d41c-4360-ba40-eaf8fd8dec85.png)