### PR TITLE
[12.0][FIX] requirements.txt: Remove duplicate apispec requirement

### DIFF
--- a/base_rest_datamodel/__manifest__.py
+++ b/base_rest_datamodel/__manifest__.py
@@ -14,7 +14,7 @@
     "demo": [],
     "external_dependencies": {
         "python": [
-            "apispec",
+            "apispec>=4.0.0",
             "marshmallow",
         ],
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # generated from manifests external_dependencies
-apispec
 apispec>=4.0.0
 cerberus
 graphene


### PR DESCRIPTION
pip install -r requirements.txt fails if there are double requirements.

Signed-off-by: Carmen Bianca Bakker <carmen@coopiteasy.be>

See also #287 