### PR TITLE
[16.0][FIX] base_rest_pydantic: forword service to PydanticModel.from_params

### DIFF
--- a/base_rest_pydantic/restapi.py
+++ b/base_rest_pydantic/restapi.py
@@ -147,7 +147,10 @@ class PydanticModelList(PydanticModel):
 
     def from_params(self, service, params):
         self._do_validate(params, "input")
-        return [super(PydanticModelList, self).from_params(param) for param in params]
+        return [
+            super(PydanticModelList, self).from_params(service, param)
+            for param in params
+        ]
 
     def to_response(self, service, result):
         self._do_validate(result, "output")

--- a/base_rest_pydantic/tests/test_from_params.py
+++ b/base_rest_pydantic/tests/test_from_params.py
@@ -23,7 +23,12 @@ class TestPydantic(TransactionCase):
         self.Model1: BaseModel = Model1
 
     def _from_params(self, pydantic_cls: Type[BaseModel], params: dict, **kwargs):
-        restapi_pydantic = restapi.PydanticModel(pydantic_cls, **kwargs)
+        restapi_pydantic_cls = (
+            restapi.PydanticModelList
+            if isinstance(params, list)
+            else restapi.PydanticModel
+        )
+        restapi_pydantic = restapi_pydantic_cls(pydantic_cls, **kwargs)
         mock_service = mock.Mock()
         mock_service.env = self.env
         return restapi_pydantic.from_params(mock_service, params)
@@ -44,3 +49,13 @@ class TestPydantic(TransactionCase):
         msg = r"value_error.missing"
         with self.assertRaisesRegex(UserError, msg):
             self._from_params(self.Model1, {"description": "Instance Description"})
+
+    def test_from_params_pydantic_model_list(self):
+        params = [
+            {"name": "Instance Name", "description": "Instance Description"},
+            {"name": "Instance Name 2", "description": "Instance Description 2"},
+        ]
+        instances = self._from_params(self.Model1, params)
+        self.assertEqual(len(instances), 2)
+        self.assertEqual(instances[0].name, params[0]["name"])
+        self.assertEqual(instances[0].description, params[0]["description"])


### PR DESCRIPTION
in subclass PydanticModelList.from_params

To reproduce create a service use PydanticModelList in input param and call that service

forward port of #292 