### PR TITLE
[IMP] rest_log: handle odoo.http.Response objects in logs

### DIFF
--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -122,6 +122,8 @@ class BaseRESTService(AbstractComponent):
         if args:
             params = dict(params or {}, args=args)
 
+        params = self._log_call_sanitize_params(params)
+
         result = kw.get("result")
         error = kw.get("traceback")
         orig_exception = kw.get("orig_exception")
@@ -151,6 +153,11 @@ class BaseRESTService(AbstractComponent):
         if not values or enabled_states and values["state"] not in enabled_states:
             return
         return env["rest.log"].sudo().create(values)
+
+    def _log_call_sanitize_params(self, params):
+        if "password" in params:
+            params["password"] = "<redacted>"
+        return params
 
     def _db_logging_active(self, method_name):
         enabled = self._log_calls_in_db

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -115,10 +115,7 @@ class BaseRESTService(AbstractComponent):
 
     def _log_call_in_db_values(self, _request, *args, params=None, **kw):
         httprequest = _request.httprequest
-        headers = dict(httprequest.headers)
-        for header_key in self._log_call_header_strip:
-            if header_key in headers:
-                headers[header_key] = "<redacted>"
+        headers = self._log_call_sanitize_headers(dict(httprequest.headers or []))
         params = dict(params or {})
         if args:
             params.update(args=args)
@@ -159,6 +156,12 @@ class BaseRESTService(AbstractComponent):
         if "password" in params:
             params["password"] = "<redacted>"
         return params
+
+    def _log_call_sanitize_headers(self, headers: dict) -> dict:
+        for header_key in self._log_call_header_strip:
+            if header_key in headers:
+                headers[header_key] = "<redacted>"
+        return headers
 
     def _db_logging_active(self, method_name):
         enabled = self._log_calls_in_db

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -9,7 +9,7 @@ import traceback
 from werkzeug.urls import url_encode, url_join
 
 from odoo import exceptions, registry
-from odoo.http import request
+from odoo.http import Response, request
 
 from odoo.addons.base_rest.http import JSONEncoder
 from odoo.addons.component.core import AbstractComponent
@@ -123,6 +123,18 @@ class BaseRESTService(AbstractComponent):
         params = self._log_call_sanitize_params(params)
 
         result = kw.get("result")
+        # NB: ``result`` might be an object of class ``odoo.http.Response``,
+        # for example when you try to download a file. In this case, we need to
+        # handle it properly, without the assumption that ``result`` is a dict.
+        if isinstance(result, Response):
+            status_code = result.status_code
+            result = {
+                "status": status_code,
+                "headers": self._log_call_sanitize_headers(dict(result.headers or [])),
+            }
+            state = "success" if status_code in range(200, 300) else "failed"
+        else:
+            state = "success" if result else "failed"
         error = kw.get("traceback")
         orig_exception = kw.get("orig_exception")
         exception_name = None
@@ -142,7 +154,7 @@ class BaseRESTService(AbstractComponent):
             "error": error,
             "exception_name": exception_name,
             "exception_message": exception_message,
-            "state": "success" if result else "failed",
+            "state": state,
         }
 
     def _log_call_in_db(self, env, _request, method_name, *args, params=None, **kw):

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -68,7 +68,7 @@ class BaseRESTService(AbstractComponent):
         log_entry = self._log_call_in_db(
             self.env, request, method_name, *args, params=params, result=result
         )
-        if log_entry:
+        if log_entry and isinstance(result, dict):
             log_entry_url = self._get_log_entry_url(log_entry)
             result["log_entry_url"] = log_entry_url
         return result

--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -119,8 +119,9 @@ class BaseRESTService(AbstractComponent):
         for header_key in self._log_call_header_strip:
             if header_key in headers:
                 headers[header_key] = "<redacted>"
+        params = dict(params or {})
         if args:
-            params = dict(params or {}, args=args)
+            params.update(args=args)
 
         params = self._log_call_sanitize_params(params)
 
@@ -154,7 +155,7 @@ class BaseRESTService(AbstractComponent):
             return
         return env["rest.log"].sudo().create(values)
 
-    def _log_call_sanitize_params(self, params):
+    def _log_call_sanitize_params(self, params: dict) -> dict:
         if "password" in params:
             params["password"] = "<redacted>"
         return params

--- a/rest_log/tests/test_db_logging.py
+++ b/rest_log/tests/test_db_logging.py
@@ -6,6 +6,7 @@ import json
 import mock
 
 from odoo import exceptions, registry
+from odoo.http import Response
 from odoo.tools import mute_logger
 
 from odoo.addons.base_rest.tests.common import (
@@ -223,6 +224,54 @@ class TestDBLogging(SavepointRestServiceRegistryCase, TestDBLoggingMixin):
         expected = self.log_model.EXCEPTION_SEVERITY_MAPPING.copy()
         expected["ValueError"] = "warning"
         self.assertEqual(mapping, expected)
+
+    def test_log_entry_values_success_with_response(self):
+        with self._get_mocked_request() as mocked_request:
+            res = Response(
+                b"A test .pdf file to download",
+                headers=[
+                    ("Content-Type", "application/pdf"),
+                    ("X-Content-Type-Options", "nosniff"),
+                    ("Content-Disposition", "attachment; filename*=UTF-8''test.pdf"),
+                    ("Content-Length", 28),
+                ],
+            )
+            res.status_code = 200
+            entry = self.service._log_call_in_db(
+                self.env, mocked_request, "method", result=res
+            )
+        self.assertEqual(entry.state, "success")
+        self.assertEqual(
+            json.loads(entry.result),
+            {
+                "headers": {
+                    "Content-Disposition": "attachment; filename*=UTF-8''test.pdf",
+                    "Content-Length": "28",
+                    "Content-Type": "application/pdf",
+                    "X-Content-Type-Options": "nosniff",
+                },
+                "status": 200,
+            },
+        )
+
+    def test_log_entry_values_failure_with_response(self):
+        with self._get_mocked_request() as mocked_request:
+            res = Response(b"", headers=[])
+            res.status_code = 418
+            entry = self.service._log_call_in_db(
+                self.env, mocked_request, "method", result=res
+            )
+        self.assertEqual(entry.state, "failed")
+        self.assertEqual(
+            json.loads(entry.result),
+            {
+                "headers": {
+                    "Content-Length": "0",
+                    "Content-Type": "text/html; charset=utf-8",
+                },
+                "status": 418,
+            },
+        )
 
 
 class TestDBLoggingException(TransactionRestServiceRegistryCase, TestDBLoggingMixin):


### PR DESCRIPTION
Handle `odoo.http.Response` objects when creating logs.