### PR TITLE
[16][FIX] base_rest: add explicit dependency to `web`, otherwise `swagger…

### DIFF
--- a/base_rest/__manifest__.py
+++ b/base_rest/__manifest__.py
@@ -12,7 +12,7 @@
     "author": "ACSONE SA/NV, " "Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],
     "website": "https://github.com/OCA/rest-framework",
-    "depends": ["component"],
+    "depends": ["component", "web"],
     "data": [
         "views/openapi_template.xml",
         "views/base_rest_view.xml",


### PR DESCRIPTION
…_ui.js` is (sometimes) loaded first, causing crashes

The exact circumstances under which `swagger_ui.js` is loaded first is not completely clear, but the addition of this dependency fixes the issue in all cases.

forward port of #272 