### PR TITLE
[14.0][FIX] base_rest_demo - odoo-addon-pydantic is used inside naive_orm_model class, but was missing in dependency

### DIFF
--- a/base_rest_demo/__manifest__.py
+++ b/base_rest_demo/__manifest__.py
@@ -17,6 +17,7 @@
         "base_rest_pydantic",
         "component",
         "extendable",
+        "pydantic",
     ],
     "data": [],
     "demo": [],


### PR DESCRIPTION
Fix missing dependency to odoo-addon-pydantic causing a runtime error when you want to use base_rest_demo.
Because the odoo-addon-pydantic is needed at this line:
https://github.com/OCA/rest-framework/blob/54e52e126931ea2e7e119f3d71c05bf5d68496ec/base_rest_demo/pydantic_models/naive_orm_model.py#L6

This fix comes from a discussion in the pull request of @StefanRijnhart  https://github.com/OCA/rest-framework/pull/313

And it should solve this issue: https://github.com/OCA/rest-framework/issues/290