### PR TITLE
[15.0] [FWD] Forward port of the fix of the missing dependancy

### DIFF
--- a/base_rest_demo/__manifest__.py
+++ b/base_rest_demo/__manifest__.py
@@ -17,6 +17,7 @@
         "base_rest_pydantic",
         "component",
         "extendable",
+        "pydantic",
     ],
     "data": [],
     "demo": [],


### PR DESCRIPTION
This is the forward port of the correction of the missing dependency from the version 14.0 https://github.com/OCA/rest-framework/pull/328

As explained in the FIX request, there is a missing dependency causing a runtime error when you want to use  base_rest_demo.
This fix adds the missing dependency allowing to use base_rest_demo.