### PR TITLE
[16.0][FIX] base_rest - When an error is trigger before the dispatcher, prams is not yet created.

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -101,7 +101,11 @@ def wrapJsonException(exception, include_description=False, extra_info=None):
             "RESTFULL call to url %s with method %s and params %s "
             "raise the following error %s"
         )
-        params = request.params.copy()
+        params = (
+            request.params.copy()
+            if hasattr(request, "params")
+            else request.get_http_params().copy()
+        )
         for k in params.keys():
             if k in BLACKLISTED_LOG_PARAMS:
                 params[k] = "<redacted>"


### PR DESCRIPTION
In some cases, when an error in trigger before dispatcher work (e.g. during authentication), the request.params is not yet created.
So the line 104 will trigger another error, causing a bad catch of an error. 