### PR TITLE
[15.0][FIX] base_rest_demo - odoo-addon-pydantic is used inside naive_orm_model class, but was missing in dependency

### DIFF
--- a/base_rest_demo/__manifest__.py
+++ b/base_rest_demo/__manifest__.py
@@ -17,6 +17,7 @@
         "base_rest_pydantic",
         "component",
         "extendable",
+        "pydantic",
     ],
     "data": [],
     "demo": [],


### PR DESCRIPTION
Forward port of https://github.com/OCA/rest-framework/pull/328
@qrtl