### PR TITLE
[15.0][IMP] Allow application/x-www-form-urlencoded encoding

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -129,7 +129,10 @@ class HttpRestRequest(HttpRequest):
                 msg = "Invalid JSON data: %s" % str(e)
                 _logger.info("%s: %s", self.httprequest.path, msg)
                 raise BadRequest(msg) from e
-        elif self.httprequest.mimetype == "multipart/form-data":
+        elif self.httprequest.mimetype in [
+            "multipart/form-data",
+            "application/x-www-form-urlencoded",
+        ]:
             # Do not reassign self.params
             pass
         else:


### PR DESCRIPTION
Next to the `multipart/form-data` encoding `application/x-www-form-urlencoded` is one of the official HTML Form encodings and as far as I can tell is also properly handled by Odoos httprequest so the rest framework should also support it.

I added `application/x-www-form-urlencoded` as another encoding where the params are not modified.