### PR TITLE
[16.0][FIX] Allow endpoint with slash in root path

### DIFF
--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -20,11 +20,14 @@ class FastApiDispatcher(Dispatcher):
         # don't parse the httprequest let starlette parse the stream
         self.request.params = {}  # dict(self.request.get_http_params(), **args)
         environ = self._get_environ()
-        root_path = "/" + environ["PATH_INFO"].split("/")[1]
+        root_path = "/".join(environ["PATH_INFO"].split("/")[0:-1])
         # TODO store the env into contextvar to be used by the odoo_env
         # depends method
         fastapi_endpoint = self.request.env["fastapi.endpoint"].sudo()
         app = fastapi_endpoint.get_app(root_path)
+        while not app and root_path:
+            root_path = "/".join(root_path.split("/")[0:-1])
+            app = fastapi_endpoint.get_app(root_path)
         uid = fastapi_endpoint.get_uid(root_path)
         data = BytesIO()
         with self._manage_odoo_env(uid):

--- a/fastapi/readme/CONTRIBUTORS.rst
+++ b/fastapi/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* Fernando La Chica <fernando.lachica@disashop.com>


### PR DESCRIPTION
If I define a endpoint with slash in `Root path` this is not found and throw an 404 error