### PR TITLE
[WIP] fastapi: mount app at root_path instead of prefixing routes and docs URLs

### DIFF
--- a/fastapi/tests/test_fastapi_demo.py
+++ b/fastapi/tests/test_fastapi_demo.py
@@ -4,8 +4,6 @@
 from functools import partial
 from unittest import mock
 
-from requests import Response
-
 import odoo
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
@@ -53,9 +51,6 @@ class FastAPIDemoCase(TransactionCase):
 
         super().tearDownClass()
 
-    def _get_path(self, path) -> str:
-        return path
-
     @mute_logger("odoo.addons.fastapi.error_handlers")
     def assert_exception_processed(
         self,
@@ -65,8 +60,8 @@ class FastAPIDemoCase(TransactionCase):
         expected_status_code: int,
     ) -> None:
         with mock.patch.object(self.env.cr.__class__, "rollback") as mock_rollback:
-            response: Response = self.client.get(
-                self._get_path("/exception"),
+            response = self.client.get(
+                "/exception",
                 params={
                     "exception_type": exception_type.value,
                     "error_message": error_message,
@@ -82,12 +77,12 @@ class FastAPIDemoCase(TransactionCase):
         )
 
     def test_hello_world(self) -> None:
-        response: Response = self.client.get(self._get_path("/"))
+        response = self.client.get("/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(response.json(), {"Hello": "World"})
 
     def test_who_ami(self) -> None:
-        response: Response = self.client.get(self._get_path("/who_ami"))
+        response = self.client.get("/who_ami")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.json(),
@@ -98,7 +93,7 @@ class FastAPIDemoCase(TransactionCase):
         )
 
     def test_endpoint_info(self) -> None:
-        response: Response = self.client.get(self._get_path("/endpoint_app_info"))
+        response = self.client.get("/endpoint_app_info")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(
             response.json(),

--- a/fastapi/tests/test_fastapi_demo.py
+++ b/fastapi/tests/test_fastapi_demo.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from requests import Response
 
+import odoo
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
 
@@ -17,6 +18,7 @@ from ..context import odoo_env_ctx
 from ..models.fastapi_endpoint_demo import EndpointAppInfo, ExceptionType
 
 
+@odoo.tests.tagged("post_install", "-at_install")
 class FastAPIDemoCase(TransactionCase):
     """The fastapi lib comes with a useful testclient that let's you
     easily test your endpoints. Moreover, the dependency overrides functionality
@@ -52,7 +54,7 @@ class FastAPIDemoCase(TransactionCase):
         super().tearDownClass()
 
     def _get_path(self, path) -> str:
-        return self.fastapi_demo_app.root_path + path
+        return path
 
     @mute_logger("odoo.addons.fastapi.error_handlers")
     def assert_exception_processed(


### PR DESCRIPTION
Since the FastAPI app for each endpoint is an independent app, mounted at a different prefix than the other, I'm wondering if the FastAPI mount mechanism would be more appropriate than prefixing all routers, prefixing the docs urls, etc.

I came to this while debugging the swagger oauth2 redirect url which is currently /docs instead of /{root_path}/docs.

When mounting the app at a prefix, FastAPI prefixes everything correctly.

This PR does not seem to work as is, but I wanted to ask if you had explored this approach @lmignon ?