### PR TITLE
[16.0][FIX] Make fastapi compatible with python 3.6

### DIFF
--- a/fastapi/README.rst
+++ b/fastapi/README.rst
@@ -203,7 +203,10 @@ that returns a list of partners.
 
 .. code-block:: python
 
-    from typing import Annotated
+    try:
+      from typing import Annotated
+    except ImportError:
+      from typing_extensions import Annotated
 
     from fastapi import APIRouter
     from pydantic import BaseModel
@@ -306,7 +309,10 @@ odoo models and the database from your route handlers.
 
 .. code-block:: python
 
-    from typing import Annotated
+    try:
+      from typing import Annotated
+    except ImportError:
+      from typing_extensions import Annotated
 
     from odoo.api import Environment
     from odoo.addons.fastapi.dependencies import odoo_env
@@ -1227,7 +1233,10 @@ you be consistent when writing a route handler for a search route.
 
 .. code-block:: python
 
-    from typing import Annotated
+    try:
+      from typing import Annotated
+    except ImportError:
+      from typing_extensions import Annotated
     from pydantic import BaseModel
 
     from odoo.api import Environment

--- a/fastapi/__manifest__.py
+++ b/fastapi/__manifest__.py
@@ -27,6 +27,7 @@
             "ujson",
             "a2wsgi",
             "parse-accept-language",
+            "typing_extensions",
         ]
     },
     "development_status": "Beta",

--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -1,7 +1,12 @@
 # Copyright 2022 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
+from typing import TYPE_CHECKING, Union
 
-from typing import TYPE_CHECKING, Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
 
 from odoo.api import Environment
 from odoo.exceptions import AccessDenied
@@ -109,7 +114,7 @@ def fastapi_endpoint(
 
 def accept_language(
     accept_language: Annotated[
-        str | None,
+        Union[str, None],
         Header(
             alias="Accept-Language",
             description="The Accept-Language header is used to specify the language "

--- a/fastapi/models/fastapi_endpoint_demo.py
+++ b/fastapi/models/fastapi_endpoint_demo.py
@@ -1,6 +1,11 @@
 # Copyright 2022 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
-from typing import Annotated, Any, List
+from typing import Any, Dict, List
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 from odoo import _, api, fields, models
 from odoo.api import Environment
@@ -71,7 +76,7 @@ class FastapiEndpoint(models.Model):
             ] = authenticated_partner_impl_override
         return app
 
-    def _prepare_fastapi_app_params(self) -> dict[str, Any]:
+    def _prepare_fastapi_app_params(self) -> Dict[str, Any]:
         params = super()._prepare_fastapi_app_params()
         if self.app == "demo":
             tags_metadata = params.get("openapi_tags", []) or []

--- a/fastapi/readme/USAGE.rst
+++ b/fastapi/readme/USAGE.rst
@@ -129,7 +129,10 @@ that returns a list of partners.
 
 .. code-block:: python
 
-    from typing import Annotated
+    try:
+      from typing import Annotated
+    except ImportError:
+      from typing_extensions import Annotated
 
     from fastapi import APIRouter
     from pydantic import BaseModel
@@ -232,7 +235,10 @@ odoo models and the database from your route handlers.
 
 .. code-block:: python
 
-    from typing import Annotated
+    try:
+      from typing import Annotated
+    except ImportError:
+      from typing_extensions import Annotated
 
     from odoo.api import Environment
     from odoo.addons.fastapi.dependencies import odoo_env
@@ -1153,7 +1159,10 @@ you be consistent when writing a route handler for a search route.
 
 .. code-block:: python
 
-    from typing import Annotated
+    try:
+      from typing import Annotated
+    except ImportError:
+      from typing_extensions import Annotated
     from pydantic import BaseModel
 
     from odoo.api import Environment

--- a/fastapi/routers/demo_router.py
+++ b/fastapi/routers/demo_router.py
@@ -4,7 +4,10 @@
 The demo router is a router that demonstrates how to use the fastapi
 integration with odoo.
 """
-from typing import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 from odoo.api import Environment
 from odoo.exceptions import AccessError, MissingError, UserError, ValidationError

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ pydantic
 pyquerystring
 python-multipart
 typing-extensions
+typing_extensions
 ujson


### PR DESCRIPTION
Try to import Annotated from typing (python 3.9+), if import error import Annotated from typing_extensions

Change the pipe operator (|) (python 3.10+) to Union from typing_extensions