### PR TITLE
[14.0] pin pydantic v1

### DIFF
--- a/base_rest_demo/__manifest__.py
+++ b/base_rest_demo/__manifest__.py
@@ -22,7 +22,7 @@
     "data": [],
     "demo": [],
     "external_dependencies": {
-        "python": ["jsondiff", "extendable-pydantic", "pydantic"]
+        "python": ["jsondiff", "extendable-pydantic", "pydantic<2"]
     },
     "installable": True,
 }

--- a/base_rest_pydantic/__manifest__.py
+++ b/base_rest_pydantic/__manifest__.py
@@ -15,7 +15,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "pydantic",
+            "pydantic<2",
         ]
     },
 }

--- a/pydantic/__manifest__.py
+++ b/pydantic/__manifest__.py
@@ -14,6 +14,6 @@
     "depends": [],
     "data": [],
     "demo": [],
-    "external_dependencies": {"python": ["pydantic", "typing-extensions"]},
+    "external_dependencies": {"python": ["pydantic<2", "typing-extensions"]},
     "installable": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ jsondiff
 marshmallow
 marshmallow-objects>=2.0.0
 parse-accept-language
-pydantic
+pydantic<2
 pyquerystring
 python-multipart
 typing-extensions


### PR DESCRIPTION
Pydantic v2 is not compatible with pydantic v1, and having code that is compatible with both is not trivial, and for the moment not supported by the `fastapi` addon, nor `extendable_pydantic`.

So in 14, we'll stick to pydantic v1. In 16 we'll use pydantic v2.