### PR TITLE
[15.0] Don't use pydantic v2

### DIFF
--- a/base_rest_demo/__manifest__.py
+++ b/base_rest_demo/__manifest__.py
@@ -22,7 +22,7 @@
     "data": [],
     "demo": [],
     "external_dependencies": {
-        "python": ["jsondiff", "extendable-pydantic", "pydantic"]
+        "python": ["jsondiff", "extendable-pydantic", "pydantic<2"]
     },
     "installable": True,
 }

--- a/base_rest_pydantic/__manifest__.py
+++ b/base_rest_pydantic/__manifest__.py
@@ -15,7 +15,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "pydantic",
+            "pydantic<2",
         ]
     },
 }

--- a/pydantic/__manifest__.py
+++ b/pydantic/__manifest__.py
@@ -15,7 +15,7 @@
     "data": [],
     "demo": [],
     "external_dependencies": {
-        "python": ["pydantic", "contextvars", "typing-extensions"]
+        "python": ["pydantic<2", "contextvars", "typing-extensions"]
     },
     "installable": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ jsondiff
 marshmallow
 marshmallow-objects>=2.0.0
 parse-accept-language
-pydantic
+pydantic<2
 pyquerystring
 typing-extensions


### PR DESCRIPTION
In 14 and 15, we'll stick to pydantic v1. In 16 we'll use pydantic v2.

Forward port of #361