### PR TITLE
[16.0][IMP] fastapi: add company_id dependency override

### DIFF
--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -19,8 +19,20 @@ if TYPE_CHECKING:
     from .models.fastapi_endpoint import FastapiEndpoint
 
 
-def odoo_env() -> Environment:
-    yield odoo_env_ctx.get()
+def company_id() -> int | None:
+    """This method may be overriden by the FastAPI app to set the allowed company
+    in the Odoo env of the endpoint. By default, the company defined on the
+    endpoint record is used.
+    """
+    return None
+
+
+def odoo_env(company_id: Annotated[int | None, Depends(company_id)]) -> Environment:
+    env = odoo_env_ctx.get()
+    if company_id is not None:
+        env = env(context=dict(env.context, allowed_company_ids=[company_id]))
+
+    yield env
 
 
 def authenticated_partner_impl() -> Partner:

--- a/fastapi/views/fastapi_endpoint.xml
+++ b/fastapi/views/fastapi_endpoint.xml
@@ -44,6 +44,7 @@
                         <field name="app" />
                         <field name="root_path" />
                         <field name="user_id" />
+                        <field name="company_id" />
                         <field name="description" />
                     </group>
                     <group name="resoures">


### PR DESCRIPTION
The company can be specified on the `fastapi.endpoint`