### PR TITLE
[FIX] fastapi: allow test with no authenticated partner

### DIFF
--- a/fastapi/tests/common.py
+++ b/fastapi/tests/common.py
@@ -1,7 +1,6 @@
 # Copyright 2023 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
 from contextlib import contextmanager
-from functools import partial
 from typing import Any, Callable, Dict
 
 from odoo.api import Environment
@@ -94,8 +93,7 @@ class FastAPITransactionCase(TransactionCase):
         if user:
             env = env(user=user)
         partner = partner or self.default_fastapi_authenticated_partner
-        if partner:
-            dependencies[authenticated_partner_impl] = partial(lambda a: a, partner)
+        dependencies[authenticated_partner_impl] = lambda: partner
         app = app or self.default_fastapi_app or FastAPI()
         router = router or self.default_fastapi_router
         if router:

--- a/fastapi/tests/common.py
+++ b/fastapi/tests/common.py
@@ -1,6 +1,7 @@
 # Copyright 2023 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
 from contextlib import contextmanager
+from functools import partial
 from typing import Any, Callable, Dict
 
 from odoo.api import Environment
@@ -92,8 +93,12 @@ class FastAPITransactionCase(TransactionCase):
             dependencies.update(dependency_overrides)
         if user:
             env = env(user=user)
-        partner = partner or self.default_fastapi_authenticated_partner
-        dependencies[authenticated_partner_impl] = lambda: partner
+        partner = (
+            partner
+            or self.default_fastapi_authenticated_partner
+            or self.env["res.partner"]
+        )
+        dependencies[authenticated_partner_impl] = partial(lambda a: a, partner)
         app = app or self.default_fastapi_app or FastAPI()
         router = router or self.default_fastapi_router
         if router:


### PR DESCRIPTION
In case you need an anonymous call in your test.
The /fastapi/tests/common.py  _create_test_client() function fails due to an empty authenticated_partner_impl.

This proposal allows you to define an empty partner for your test:
 `cls.default_fastapi_authenticated_partner = cls.env["res.partner"]`
 
An authenticated test can be done like this: 
`self._create_test_client(partner=self.test_partner)`