### PR TITLE
[16.0][FIX] extendable_fastapi: Coercion must be possible

### DIFF
--- a/base_rest_demo/tests/data/partner_pydantic_api.json
+++ b/base_rest_demo/tests/data/partner_pydantic_api.json
@@ -198,24 +198,7 @@
   "openapi": "3.0.0",
   "components": {
     "schemas": {
-      "StateInfo": {
-        "title": "StateInfo",
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          }
-        },
-        "required": ["id", "name"]
-      },
       "CountryInfo": {
-        "title": "CountryInfo",
-        "type": "object",
         "properties": {
           "id": {
             "title": "Id",
@@ -226,11 +209,26 @@
             "type": "string"
           }
         },
-        "required": ["id", "name"]
+        "required": ["id", "name"],
+        "title": "CountryInfo",
+        "type": "object"
+      },
+      "StateInfo": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": ["id", "name"],
+        "title": "StateInfo",
+        "type": "object"
       },
       "PartnerInfo": {
-        "title": "PartnerInfo",
-        "type": "object",
         "properties": {
           "id": {
             "title": "Id",
@@ -245,12 +243,12 @@
             "type": "string"
           },
           "street2": {
+            "default": null,
             "title": "Street2",
-            "type": "string",
-            "default": null
+            "type": "string"
           },
-          "zip": {
-            "title": "Zip",
+          "zip_code": {
+            "title": "Zip Code",
             "type": "string"
           },
           "city": {
@@ -258,9 +256,9 @@
             "type": "string"
           },
           "phone": {
+            "default": null,
             "title": "Phone",
-            "type": "string",
-            "default": null
+            "type": "string"
           },
           "state": {
             "$ref": "#/components/schemas/StateInfo"
@@ -269,48 +267,16 @@
             "$ref": "#/components/schemas/CountryInfo"
           },
           "is_company": {
+            "default": null,
             "title": "Is Company",
-            "type": "boolean",
-            "default": null
+            "type": "boolean"
           }
         },
-        "required": ["id", "name", "street", "zip", "city", "state", "country"],
-        "$defs": {
-          "StateInfo": {
-            "title": "StateInfo",
-            "type": "object",
-            "properties": {
-              "id": {
-                "title": "Id",
-                "type": "integer"
-              },
-              "name": {
-                "title": "Name",
-                "type": "string"
-              }
-            },
-            "required": ["id", "name"]
-          },
-          "CountryInfo": {
-            "title": "CountryInfo",
-            "type": "object",
-            "properties": {
-              "id": {
-                "title": "Id",
-                "type": "integer"
-              },
-              "name": {
-                "title": "Name",
-                "type": "string"
-              }
-            },
-            "required": ["id", "name"]
-          }
-        }
+        "required": ["id", "name", "street", "zip_code", "city", "state", "country"],
+        "title": "PartnerInfo",
+        "type": "object"
       },
       "PartnerShortInfo": {
-        "title": "PartnerShortInfo",
-        "type": "object",
         "properties": {
           "id": {
             "title": "Id",
@@ -321,7 +287,9 @@
             "type": "string"
           }
         },
-        "required": ["id", "name"]
+        "required": ["id", "name"],
+        "title": "PartnerShortInfo",
+        "type": "object"
       }
     },
     "securitySchemes": {

--- a/base_rest_pydantic/restapi.py
+++ b/base_rest_pydantic/restapi.py
@@ -114,10 +114,10 @@ class PydanticModel(restapi.RestMethodParam):
         }
 
     def to_json_schema(self, service, spec, direction):
-        schema = self._model_cls.model_json_schema()
+        schema = self._model_cls.model_json_schema(by_alias=False)
         schema_name = schema["title"]
         if schema_name not in spec.components.schemas:
-            definitions = schema.get("$defs", {})
+            definitions = schema.pop("$defs", {})
             for name, sch in definitions.items():
                 if name in spec.components.schemas:
                     continue

--- a/extendable_fastapi/schemas.py
+++ b/extendable_fastapi/schemas.py
@@ -6,7 +6,6 @@ class StrictExtendableBaseModel(
     revalidate_instances="always",
     validate_assignment=True,
     extra="forbid",
-    strict=True,
 ):
     """
     An ExtendableBaseModel with strict validation.
@@ -24,6 +23,4 @@ class StrictExtendableBaseModel(
     (default is "never")
     * validate_assignment=True: revalidate the model when the data is changed (default is False)
     * extra="forbid": Forbid any extra attributes (default is "ignore")
-    * strict=True: raise an error if a value's type does not match the field's type
-    annotation (default is False; Pydantic attempts to coerce values to the correct type)
     """

--- a/extendable_fastapi/tests/test_strict_extendable_base_model.py
+++ b/extendable_fastapi/tests/test_strict_extendable_base_model.py
@@ -55,14 +55,9 @@ class TestStrictExtendableBaseModel(FastAPITransactionCase):
         with self.assertRaises(ValidationError):
             self.StrictModel(x=1, z=3, d=None)
 
-    def test_Model_strict_false(self):
-        # Coerce str->date is allowed
-        m = self.Model(x=1, d=None)
+    def test_StrictModel_strict_false(self):
+        # Coerce str->date is allowed to enable coercion from JSON
+        # by FastAPI
+        m = self.StrictModel(x=1, d=None)
         m.d = "2023-01-01"
         self.assertTrue(m.model_validate(m))
-
-    def test_StrictModel_strict_true(self):
-        # Coerce str->date is forbidden
-        m = self.StrictModel(x=1, d=None)
-        with self.assertRaises(ValidationError):
-            m.d = "2023-01-01"


### PR DESCRIPTION
On the StrictExtendableBaseModel, disable strict mode to enable coercion from json by FastAPI