### PR TITLE
[FIX] Corrected a Field parameter typo in schemas.py

### DIFF
--- a/fastapi/schemas.py
+++ b/fastapi/schemas.py
@@ -14,7 +14,7 @@ class PagedCollection(BaseModel, Generic[T]):
         int,
         Field(
             ...,
-            desciption="Count of items into the system.\n "
+            description="Count of items into the system.\n "
             "Replaces the total field which is deprecated",
             validation_alias=AliasChoices("count", "total"),
         ),


### PR DESCRIPTION
Misspelt parameter was triggering a deprecation warning due to recent versions of Pydantic seeing it as an arbitrary parameter:

PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'desciption').