### PR TITLE
[16.0][FIX] fastapi_auth_jwt: unauthenticated partner

### DIFF
--- a/fastapi_auth_jwt/dependencies.py
+++ b/fastapi_auth_jwt/dependencies.py
@@ -204,8 +204,9 @@ class AuthJwtPartner(BaseAuthJwt):
         except Unauthorized as e:
             raise HTTPException(status_code=HTTP_401_UNAUTHORIZED) from e
         if not partner_id:
-            _logger.info("Could not determine partner from JWT payload.")
-            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED)
+            if not self.allow_unauthenticated or validator.partner_id_required:
+                _logger.info("Could not determine partner from JWT payload.")
+                raise HTTPException(status_code=HTTP_401_UNAUTHORIZED)
         return env["res.partner"].with_user(uid).browse(partner_id)
 
 


### PR DESCRIPTION
Don't raise error if partner not found and unauthenticated partner is allowed