### PR TITLE
Revert "[FIX] fastapi: close cursor after rollback"

### DIFF
--- a/fastapi/error_handlers.py
+++ b/fastapi/error_handlers.py
@@ -23,15 +23,10 @@ _logger = logging.getLogger(__name__)
 
 
 def _rollback(request: Request, reason: str) -> None:
-    env = odoo_env_ctx.get()
-    cr = env.cr
+    cr = odoo_env_ctx.get().cr
     if cr is not None:
         _logger.debug("rollback on %s", reason)
         cr.rollback()
-        # Also close the cursor, so `retrying` in service/model.py does not attempt to
-        # flush.
-        if not (env.registry.in_test_mode()):
-            cr.close()
 
 
 async def _odoo_user_error_handler(

--- a/fastapi/tests/test_fastapi_demo.py
+++ b/fastapi/tests/test_fastapi_demo.py
@@ -47,9 +47,7 @@ class FastAPIDemoCase(FastAPITransactionCase):
             demo_app._get_app(), raise_server_exceptions=False
         ) as test_client, mock.patch.object(
             self.env.cr.__class__, "rollback"
-        ) as mock_rollback, mock.patch.object(
-            self.env.cr.__class__, "close"
-        ) as mock_close:
+        ) as mock_rollback:
             response: Response = test_client.get(
                 "/demo/exception",
                 params={
@@ -58,7 +56,6 @@ class FastAPIDemoCase(FastAPITransactionCase):
                 },
             )
             mock_rollback.assert_called_once()
-            mock_close.assert_called_once()
         self.assertEqual(response.status_code, expected_status_code)
         self.assertDictEqual(
             response.json(),


### PR DESCRIPTION
This reverts commit 8be7fbb0fda92b46e4913176185fb4e19ab319be.

Revert #405 because my analysis of the issue was incorrect.

In case of exception in the fastapi layer, the environment is cleared so retrying will have nothing to flush.
