### PR TITLE
[17.0] Changed the version in menifest for v17

### DIFF
--- a/fastapi/__manifest__.py
+++ b/fastapi/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Odoo FastAPI",
     "summary": """
         Odoo FastAPI endpoint""",
-    "version": "16.0.1.2.1",
+    "version": "17.0.1.0.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],


### PR DESCRIPTION
Fixed the version error during installation in v17.

ValueError: Invalid version '16.0.1.2.1'. Modules should have a version in format `x.y`, `x.y.z`, `17.0.x.y` or `17.0.x.y.z`