### PR TITLE
[16.0][FIX] fastapi: add missing dependency

### DIFF
--- a/fastapi/__manifest__.py
+++ b/fastapi/__manifest__.py
@@ -10,7 +10,10 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],
     "website": "https://github.com/OCA/rest-framework",
-    "depends": ["endpoint_route_handler"],
+    "depends": [
+        "base_rest",
+        "endpoint_route_handler",
+    ],
     "data": [
         "security/res_groups.xml",
         "security/fastapi_endpoint.xml",


### PR DESCRIPTION
`security/ir_rule+acl.xml` refers to `authenticated_partner_id` which is defined in `base_rest`

Fixes: #367