### PR TITLE
[14.0] [IMP] rest_log: add MissingError to dispatch method

### DIFF
--- a/rest_log/components/service.py
+++ b/rest_log/components/service.py
@@ -16,6 +16,7 @@ from odoo.addons.component.core import AbstractComponent
 
 from ..exceptions import (
     RESTServiceDispatchException,
+    RESTServiceMissingErrorException,
     RESTServiceUserErrorException,
     RESTServiceValidationErrorException,
 )
@@ -41,6 +42,14 @@ class BaseRESTService(AbstractComponent):
         # https://github.com/OCA/rest-framework/pull/106#pullrequestreview-582099258
         try:
             result = super().dispatch(method_name, *args, params=params)
+        except exceptions.MissingError as orig_exception:
+            self._dispatch_exception(
+                method_name,
+                RESTServiceMissingErrorException,
+                orig_exception,
+                *args,
+                params=params,
+            )
         except exceptions.ValidationError as orig_exception:
             self._dispatch_exception(
                 method_name,

--- a/rest_log/exceptions.py
+++ b/rest_log/exceptions.py
@@ -13,6 +13,12 @@ class RESTServiceDispatchException(Exception):
         self.rest_json_info = {"log_entry_url": log_entry_url}
 
 
+class RESTServiceMissingErrorException(
+    RESTServiceDispatchException, odoo_exceptions.MissingError
+):
+    """Missing error wrapped exception."""
+
+
 class RESTServiceUserErrorException(
     RESTServiceDispatchException, odoo_exceptions.UserError
 ):


### PR DESCRIPTION
Add `RESTServiceMissingErrorException` to the exceptions to have the right status code returned when a `MissingError` is raised and intercepted