### PR TITLE
[17.0] [FIX] Invalid version '15.0.1.0.1'. Modules should have a version in format `17.0.x.y.z`

### DIFF
--- a/base_rest/__manifest__.py
+++ b/base_rest/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """
         Develop your own high level REST APIs for Odoo thanks to this addon.
         """,
-    "version": "16.0.1.0.2",
+    "version": "17.0.1.0.2",
     "development_status": "Beta",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV, " "Odoo Community Association (OCA)",

--- a/base_rest_auth_api_key/__manifest__.py
+++ b/base_rest_auth_api_key/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """
         Base Rest: Add support for the auth_api_key security policy into the
         openapi documentation""",
-    "version": "16.0.1.0.0",
+    "version": "17.0.1.0.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",

--- a/base_rest_auth_jwt/__manifest__.py
+++ b/base_rest_auth_jwt/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """
         Base Rest: Add support for the auth_jwt security policy into the
         openapi documentation""",
-    "version": "15.0.1.1.0",
+    "version": "17.0.1.1.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",

--- a/base_rest_auth_user_service/__manifest__.py
+++ b/base_rest_auth_user_service/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "REST Authentication Service",
     "summary": "Login/logout from session using a REST call",
-    "version": "15.0.1.0.1",
+    "version": "17.0.1.0.1",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "website": "https://github.com/OCA/rest-framework",

--- a/base_rest_datamodel/__manifest__.py
+++ b/base_rest_datamodel/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Base Rest Datamodel",
     "summary": """
         Datamodel binding for base_rest""",
-    "version": "16.0.1.0.0",
+    "version": "17.0.1.0.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",

--- a/base_rest_demo/__manifest__.py
+++ b/base_rest_demo/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Base Rest Demo",
     "summary": """
         Demo addon for Base REST""",
-    "version": "16.0.2.0.2",
+    "version": "17.0.2.0.2",
     "development_status": "Beta",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV, " "Odoo Community Association (OCA)",

--- a/base_rest_pydantic/__manifest__.py
+++ b/base_rest_pydantic/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Base Rest Datamodel",
     "summary": """
         Pydantic binding for base_rest""",
-    "version": "16.0.2.0.1",
+    "version": "17.0.2.0.1",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",

--- a/datamodel/__manifest__.py
+++ b/datamodel/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """
         This addon allows you to define simple data models supporting
         serialization/deserialization""",
-    "version": "16.0.1.0.1",
+    "version": "17.0.1.0.1",
     "license": "LGPL-3",
     "development_status": "Beta",
     "author": "ACSONE SA/NV, " "Odoo Community Association (OCA)",

--- a/extendable/__manifest__.py
+++ b/extendable/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Extendable",
     "summary": """
         Extendable classes registry loader for Odoo""",
-    "version": "16.0.1.0.1",
+    "version": "17.0.1.0.1",
     "development_status": "Beta",
     "maintainers": ["lmignon"],
     "license": "LGPL-3",

--- a/extendable_fastapi/__manifest__.py
+++ b/extendable_fastapi/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Extendable Fastapi",
     "summary": """
         Allows the use of extendable into fastapi apps""",
-    "version": "16.0.2.1.1",
+    "version": "17.0.2.1.1",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],

--- a/fastapi/__manifest__.py
+++ b/fastapi/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Odoo FastAPI",
     "summary": """
         Odoo FastAPI endpoint""",
-    "version": "16.0.1.2.1",
+    "version": "17.0.1.2.1",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],

--- a/fastapi_auth_jwt/__manifest__.py
+++ b/fastapi_auth_jwt/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "FastAPI Auth JWT support",
     "summary": """
         JWT bearer token authentication for FastAPI.""",
-    "version": "16.0.1.0.1",
+    "version": "17.0.1.0.1",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["sbidoul"],

--- a/fastapi_auth_jwt_demo/__manifest__.py
+++ b/fastapi_auth_jwt_demo/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "FastAPI Auth JWT Test",
     "summary": """
         Test/demo module for fastapi_auth_jwt.""",
-    "version": "16.0.2.0.0",
+    "version": "17.0.2.0.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["sbidoul"],

--- a/graphql_base/__manifest__.py
+++ b/graphql_base/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Graphql Base",
     "summary": """
         Base GraphQL/GraphiQL controller""",
-    "version": "16.0.1.0.1",
+    "version": "17.0.1.0.1",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",

--- a/graphql_demo/__manifest__.py
+++ b/graphql_demo/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "GraphQL Demo",
-    "version": "16.0.1.0.1",
+    "version": "17.0.1.0.1",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rest-framework",

--- a/model_serializer/__manifest__.py
+++ b/model_serializer/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Model Serializer",
     "summary": "Automatically translate Odoo models into Datamodels "
     "for (de)serialization",
-    "version": "15.0.1.2.0",
+    "version": "17.0.1.2.0",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "website": "https://github.com/OCA/rest-framework",

--- a/pydantic/__manifest__.py
+++ b/pydantic/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Pydantic",
     "summary": """
         Utility addon to ease mapping between Pydantic and Odoo models""",
-    "version": "16.0.1.0.0",
+    "version": "17.0.1.0.0",
     "development_status": "Beta",
     "license": "LGPL-3",
     "maintainers": ["lmignon"],

--- a/rest_log/__manifest__.py
+++ b/rest_log/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "REST Log",
     "summary": "Track REST API calls into DB",
-    "version": "15.0.1.0.0",
+    "version": "17.0.1.0.0",
     "development_status": "Beta",
     "website": "https://github.com/OCA/rest-framework",
     "author": "Camptocamp, ACSONE, Odoo Community Association (OCA)",


### PR DESCRIPTION
After git clone this Odoo repo no longer wants to start because the version of the modules is not correct

```
 ValueError: Invalid version '15.0.1.0.1'. Modules should have a version in format `x.y`, `x.y.z`, `17.0.x.y` or `17.0.x.y.z`.
ValueError: Module base_rest_auth_user_service: invalid manifest
```