### PR TITLE
[16.0][FIX] fastapi: Handle error occurring outside the fastapi processing

### DIFF
--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -4,6 +4,8 @@
 from contextlib import contextmanager
 from io import BytesIO
 
+from werkzeug.exceptions import InternalServerError
+
 from odoo.http import Dispatcher, request
 
 from .context import odoo_env_ctx
@@ -35,7 +37,10 @@ class FastApiDispatcher(Dispatcher):
             )
 
     def handle_error(self, exc):
-        pass
+        # At this stage all the normal exceptions are handled by FastAPI
+        # and we should only have InternalServerError occurring after the
+        # FastAPI app has been called.
+        return InternalServerError()  # pragma: no cover
 
     def _make_response(self, status_mapping, headers_tuple, content):
         self.status = status_mapping[:3]


### PR DESCRIPTION
To ensure that exception orrurring outside of the fastapi processing stack are properly handled, implement the 'handle_error' method into the FastApiDispatcher class

The `handle_error` method is the last one called by the WSGI app [when processing an exception](https://github.com/odoo/odoo/blob/16.0/odoo/http.py#L2070).... Therefore it must be implemented.