### PR TITLE
[FIX] requirements: fixes no module named typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ apispec
 apispec>=4.0.0
 cerberus
 contextvars
-extendable-pydantic
-extendable-pydantic>=1.2.0
+extendable-pydantic==1.3.0
 extendable>=0.0.4
 fastapi
 graphene
@@ -14,8 +13,7 @@ jsondiff
 marshmallow
 marshmallow-objects>=2.0.0
 parse-accept-language
-pydantic
-pydantic>=2.0.0
+pydantic==2.6.1
 pyquerystring
 python-multipart
 typing-extensions


### PR DESCRIPTION
fixes https://github.com/OCA/rest-framework/issues/423

This error is not longer showing after using fixed version of those libraries.

```
Before:
Error processing line 1 of /opt/odoo/.local/lib/python3.10/site-packages/extendable_pydantic_patcher.pth:
Step #4: 
Step #4:   Traceback (most recent call last):
Step #4:     File "/usr/local/lib/python3.10/site.py", line 186, in addpackage
Step #4:       exec(line)
Step #4:     File "<string>", line 1, in <module>
Step #4:     File "/opt/odoo/.local/lib/python3.10/site-packages/extendable_pydantic/__init__.py", line 4, in <module>
Step #4:       from .main import ExtendableModelMeta
Step #4:     File "/opt/odoo/.local/lib/python3.10/site-packages/extendable_pydantic/main.py", line 17, in <module>
Step #4:       from pydantic._internal._model_construction import ModelMetaclass
Step #4:     File "/opt/odoo/.local/lib/python3.10/site-packages/pydantic/__init__.py", line 368, in <module>
Step #4:       _getattr_migration = getattr_migration(__name__)
Step #4:     File "/opt/odoo/.local/lib/python3.10/site-packages/pydantic/_migration.py", line 260, in getattr_migration
Step #4:       from .errors import PydanticImportError
Step #4:     File "/opt/odoo/.local/lib/python3.10/site-packages/pydantic/errors.py", line 6, in <module>
Step #4:       from typing_extensions import Literal, Self
Step #4:   ModuleNotFoundError: No module named 'typing_extensions'

After:
Collecting a2wsgi (from -r requirements.txt (line 2))
  Downloading a2wsgi-1.10.4-py3-none-any.whl.metadata (3.9 kB)
Requirement already satisfied: apispec in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 3)) (6.3.0)
Requirement already satisfied: cerberus in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 5)) (1.3.5)
Collecting contextvars (from -r requirements.txt (line 6))
  Downloading contextvars-2.4.tar.gz (9.6 kB)
  Preparing metadata (setup.py) ... done
Collecting extendable-pydantic==1.3.0 (from -r requirements.txt (line 7))
  Downloading extendable_pydantic-1.3.0-py3-none-any.whl.metadata (3.8 kB)
Requirement already satisfied: extendable>=0.0.4 in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 8)) (1.2.2)
Collecting fastapi (from -r requirements.txt (line 9))
  Downloading fastapi-0.110.0-py3-none-any.whl.metadata (25 kB)
Requirement already satisfied: graphene in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 10)) (3.3)
Requirement already satisfied: graphql_server in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 11)) (3.0.0b7)
Requirement already satisfied: jsondiff in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 12)) (2.0.0)
Requirement already satisfied: marshmallow in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 13)) (3.20.1)
Requirement already satisfied: marshmallow-objects>=2.0.0 in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 14)) (2.3.0)
Requirement already satisfied: parse-accept-language in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 15)) (0.1.2)
Collecting pydantic==2.6.1 (from -r requirements.txt (line 16))
  Downloading pydantic-2.6.1-py3-none-any.whl.metadata (83 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 83.5/83.5 kB 1.4 MB/s eta 0:00:00
Requirement already satisfied: pyquerystring in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 17)) (1.1)
Collecting python-multipart (from -r requirements.txt (line 18))
  Downloading python_multipart-0.0.9-py3-none-any.whl.metadata (2.5 kB)
Requirement already satisfied: typing-extensions in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from -r requirements.txt (line 19)) (4.8.0)
Collecting ujson (from -r requirements.txt (line 20))
  Downloading ujson-5.9.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (8.7 kB)
Requirement already satisfied: wrapt in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from extendable-pydantic==1.3.0->-r requirements.txt (line 7)) (1.15.0)
Collecting annotated-types>=0.4.0 (from pydantic==2.6.1->-r requirements.txt (line 16))
  Downloading annotated_types-0.6.0-py3-none-any.whl.metadata (12 kB)
Collecting pydantic-core==2.16.2 (from pydantic==2.6.1->-r requirements.txt (line 16))
  Downloading pydantic_core-2.16.2-cp310-cp310-macosx_11_0_arm64.whl.metadata (6.5 kB)
Requirement already satisfied: packaging>=21.3 in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from apispec->-r requirements.txt (line 3)) (23.2)
Collecting immutables>=0.9 (from contextvars->-r requirements.txt (line 6))
  Downloading immutables-0.20-cp310-cp310-macosx_11_0_arm64.whl.metadata (4.6 kB)
Collecting starlette<0.37.0,>=0.36.3 (from fastapi->-r requirements.txt (line 9))
  Downloading starlette-0.36.3-py3-none-any.whl.metadata (5.9 kB)
Requirement already satisfied: graphql-core<3.3,>=3.1 in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from graphene->-r requirements.txt (line 10)) (3.2.3)
Requirement already satisfied: graphql-relay<3.3,>=3.1 in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from graphene->-r requirements.txt (line 10)) (3.2.0)
Requirement already satisfied: aniso8601<10,>=8 in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from graphene->-r requirements.txt (line 10)) (9.0.1)
Collecting anyio<5,>=3.4.0 (from starlette<0.37.0,>=0.36.3->fastapi->-r requirements.txt (line 9))
  Downloading anyio-4.3.0-py3-none-any.whl.metadata (4.6 kB)
Requirement already satisfied: idna>=2.8 in /Users/andresr/dev/odoo/15/.venv/lib/python3.10/site-packages (from anyio<5,>=3.4.0->starlette<0.37.0,>=0.36.3->fastapi->-r requirements.txt (line 9)) (2.8)
Collecting sniffio>=1.1 (from anyio<5,>=3.4.0->starlette<0.37.0,>=0.36.3->fastapi->-r requirements.txt (line 9))
  Downloading sniffio-1.3.1-py3-none-any.whl.metadata (3.9 kB)
Collecting exceptiongroup>=1.0.2 (from anyio<5,>=3.4.0->starlette<0.37.0,>=0.36.3->fastapi->-r requirements.txt (line 9))
  Using cached exceptiongroup-1.2.0-py3-none-any.whl.metadata (6.6 kB)
Downloading extendable_pydantic-1.3.0-py3-none-any.whl (10 kB)
Downloading pydantic-2.6.1-py3-none-any.whl (394 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 394.8/394.8 kB 3.9 MB/s eta 0:00:00
Downloading pydantic_core-2.16.2-cp310-cp310-macosx_11_0_arm64.whl (1.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 10.7 MB/s eta 0:00:00
Downloading a2wsgi-1.10.4-py3-none-any.whl (16 kB)
Downloading fastapi-0.110.0-py3-none-any.whl (92 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 92.1/92.1 kB 9.1 MB/s eta 0:00:00
Downloading python_multipart-0.0.9-py3-none-any.whl (22 kB)
Downloading ujson-5.9.0-cp310-cp310-macosx_11_0_arm64.whl (54 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.1/54.1 kB 8.9 MB/s eta 0:00:00
Downloading annotated_types-0.6.0-py3-none-any.whl (12 kB)
Downloading immutables-0.20-cp310-cp310-macosx_11_0_arm64.whl (32 kB)
Downloading starlette-0.36.3-py3-none-any.whl (71 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 71.5/71.5 kB 10.2 MB/s eta 0:00:00
Downloading anyio-4.3.0-py3-none-any.whl (85 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 85.6/85.6 kB 7.6 MB/s eta 0:00:00
Using cached exceptiongroup-1.2.0-py3-none-any.whl (16 kB)
Downloading sniffio-1.3.1-py3-none-any.whl (10 kB)
Building wheels for collected packages: contextvars
  Building wheel for contextvars (setup.py) ... done
  Created wheel for contextvars: filename=contextvars-2.4-py3-none-any.whl size=7665 sha256=6ad0cf36e4e746207e2e26a99d275828f41e15510209ba9e494ec526d2cf673b
  Stored in directory: /Users/andresr/Library/Caches/pip/wheels/f9/2c/c9/4b330908a23ee28818243dbd3925b0a5254f8bb9d659bf6b6a
Successfully built contextvars
Installing collected packages: ujson, sniffio, python-multipart, pydantic-core, immutables, exceptiongroup, annotated-types, a2wsgi, pydantic, contextvars, anyio, starlette, extendable-pydantic, fastapi
  Attempting uninstall: pydantic
    Found existing installation: pydantic 1.10.13
    Uninstalling pydantic-1.10.13:
      Successfully uninstalled pydantic-1.10.13
  Attempting uninstall: extendable-pydantic
    Found existing installation: extendable_pydantic 0.0.6
    Uninstalling extendable_pydantic-0.0.6:
      Successfully uninstalled extendable_pydantic-0.0.6
Successfully installed a2wsgi-1.10.4 annotated-types-0.6.0 anyio-4.3.0 contextvars-2.4 exceptiongroup-1.2.0 extendable-pydantic-1.3.0 fastapi-0.110.0 immutables-0.20 pydantic-2.6.1 pydantic-core-2.16.2 python-multipart-0.0.9 sniffio-1.3.1 starlette-0.36.3 ujson-5.9.0
```