### PR TITLE
FastAPI Auth JWT: Fixes incorrect environment access 

### DIFF
--- a/fastapi_auth_jwt/dependencies.py
+++ b/fastapi_auth_jwt/dependencies.py
@@ -236,7 +236,7 @@ class AuthJwtOdooEnv(BaseAuthJwt):
             request, response, authorization_header, validator
         )
         uid = validator._get_and_check_uid(payload)
-        return odoo_env(user=uid)
+        return env(user=uid)
 
 
 auth_jwt_authenticated_payload = AuthJwtPayload()


### PR DESCRIPTION
It seems that the incorrect environment is used in the return of `AuthJwtOdooEnv`.
Instead of odoo_env (which ist no Environment, but a dependency, that only accepts a company_id), the actual Environment returned by the odoo_env dependency should be upgraded and returned.

Possible fix of #383 & #426.

closes #406 