### PR TITLE
[16.0] [IMP] fastapi: Add endpoint public_url field

### DIFF
--- a/fastapi/models/fastapi_endpoint.py
+++ b/fastapi/models/fastapi_endpoint.py
@@ -48,6 +48,11 @@ class FastapiEndpoint(models.Model):
     docs_url: str = fields.Char(compute="_compute_urls")
     redoc_url: str = fields.Char(compute="_compute_urls")
     openapi_url: str = fields.Char(compute="_compute_urls")
+    public_url: str = fields.Char(
+        help="The public URL of the API.\n"
+        "This is an informative data item that can be used by "
+        "other modules, for example, to construct URLs in mails."
+    )
     company_id = fields.Many2one(
         "res.company",
         compute="_compute_company_id",

--- a/fastapi/models/fastapi_endpoint_demo.py
+++ b/fastapi/models/fastapi_endpoint_demo.py
@@ -28,7 +28,7 @@ class FastapiEndpoint(models.Model):
     )
     demo_auth_method = fields.Selection(
         selection=[("api_key", "Api Key"), ("http_basic", "HTTP Basic")],
-        string="Authenciation method",
+        string="Authentication method",
     )
 
     def _get_fastapi_routers(self) -> List[APIRouter]:

--- a/fastapi/views/fastapi_endpoint.xml
+++ b/fastapi/views/fastapi_endpoint.xml
@@ -51,6 +51,11 @@
                         <field name="docs_url" widget="url" />
                         <field name="redoc_url" widget="url" />
                         <field name="openapi_url" widget="url" />
+                        <field
+                                name="public_url"
+                                widget="url"
+                                placeholder="https://api.shop.example.com/"
+                            />
                     </group>
                     </group>
                     <span name="configuration" />
@@ -95,6 +100,7 @@
                 <field name="docs_url" widget="url" />
                 <field name="redoc_url" widget="url" />
                 <field name="openapi_url" widget="url" />
+                <field name="public_url" widget="url" />
                 <button
                     name="action_sync_registry"
                     string="Sync Registry"


### PR DESCRIPTION
This introduces an optional `public_url` field in order to avoid hardcoding external site url in mails. 

(Also used to implement impersonation in fastapi_auth_partner)