### PR TITLE
[16.0] [FIX] fastapi: Unflag save_session in routing info

### DIFF
--- a/fastapi/models/fastapi_endpoint.py
+++ b/fastapi/models/fastapi_endpoint.py
@@ -55,6 +55,16 @@ class FastapiEndpoint(models.Model):
         readonly=False,
         domain="[('user_ids', 'in', user_id)]",
     )
+    save_http_session = fields.Boolean(
+        string="Save HTTP Session",
+        help="Whether session should be saved into the session store. This is "
+        "required if for example you use the Odoo's authentication mechanism. "
+        "Oherwise chance are high that you don't need it and could turn off "
+        "this behaviour. Additionaly turning off this option will prevent useless "
+        "IO operation when storing and reading the session on the disk and prevent "
+        "unexpecteed disk space consumption.",
+        default=True,
+    )
 
     @api.depends("root_path")
     def _compute_root_path(self):
@@ -178,7 +188,7 @@ class FastapiEndpoint(models.Model):
                 f"{self.root_path}/",
                 f"{self.root_path}/<path:application_path>",
             ],
-            "save_session": False,
+            "save_session": self.save_http_session,
             # csrf ?????
         }
 

--- a/fastapi/models/fastapi_endpoint.py
+++ b/fastapi/models/fastapi_endpoint.py
@@ -178,6 +178,7 @@ class FastapiEndpoint(models.Model):
                 f"{self.root_path}/",
                 f"{self.root_path}/<path:application_path>",
             ],
+            "save_session": False,
             # csrf ?????
         }
 

--- a/fastapi/readme/newsfragments/442.feature
+++ b/fastapi/readme/newsfragments/442.feature
@@ -1,0 +1,1 @@
+* A new parameter is now available on the endpoint model to let you disable the creation and the store of session files used by Odoo for calls to your application endpoint. This is usefull to prevent disk space consumption and IO operations if your application doesn't need to use this sessions files which are mainly used by Odoo by to store the session info of logged in users.

--- a/fastapi/views/fastapi_endpoint.xml
+++ b/fastapi/views/fastapi_endpoint.xml
@@ -46,7 +46,7 @@
                         <field name="user_id" />
                         <field name="company_id" />
                         <field name="description" />
-                    </group>
+                        <field name="save_http_session" />                    </group>
                     <group name="resoures">
                         <field name="docs_url" widget="url" />
                         <field name="redoc_url" widget="url" />

--- a/fastapi/views/fastapi_endpoint.xml
+++ b/fastapi/views/fastapi_endpoint.xml
@@ -46,7 +46,8 @@
                         <field name="user_id" />
                         <field name="company_id" />
                         <field name="description" />
-                        <field name="save_http_session" />                    </group>
+                        <field name="save_http_session" />
+                    </group>
                     <group name="resoures">
                         <field name="docs_url" widget="url" />
                         <field name="redoc_url" widget="url" />


### PR DESCRIPTION
This is as much a PR as a question.

Is there any reason to not set the `save_session` to False and thus remove the `session_id` cookie? 

FYI: @sebastienbeau 