### PR TITLE
[16.0][FIX] fastapi: paging - correctly set authorised minimal value in paging function

### DIFF
--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -101,7 +101,7 @@ def optionally_authenticated_partner(
 
 
 def paging(
-    page: Annotated[int, Query(gte=1)] = 1, page_size: Annotated[int, Query(gte=1)] = 80
+    page: Annotated[int, Query(ge=1)] = 1, page_size: Annotated[int, Query(ge=1)] = 80
 ) -> Paging:
     """Return a Paging object from the page and page_size parameters"""
     return Paging(limit=page_size, offset=(page - 1) * page_size)


### PR DESCRIPTION
# Small fix

`fastapi.Query` accepts several parameters (`ge`,`gt`,`le`,`lt`) but not `gte`. 

I think that the intention was to set the minimal value to 1. Therefore, `ge` should be used.