### PR TITLE
[FIX] fastapi_auth_jwt_demo: assign and show Auth Jwt Validator

### DIFF
--- a/fastapi_auth_jwt_demo/README.rst
+++ b/fastapi_auth_jwt_demo/README.rst
@@ -56,6 +56,11 @@ Authors
 
 * ACSONE SA/NV
 
+Contributors
+~~~~~~~~~~~~
+
+Mohamed Alkobrosli <alkobroslymohamed@gmail.com>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/fastapi_auth_jwt_demo/__manifest__.py
+++ b/fastapi_auth_jwt_demo/__manifest__.py
@@ -10,7 +10,9 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["sbidoul"],
     "website": "https://github.com/OCA/rest-framework",
-    "depends": ["fastapi_auth_jwt", "auth_jwt_demo"],
-    "data": [],
+    "depends": ["fastapi", "fastapi_auth_jwt", "auth_jwt_demo"],
+    "data": [
+        "views/fastapi_endpoint_demo.xml",
+    ],
     "demo": ["demo/fastapi_endpoint.xml"],
 }

--- a/fastapi_auth_jwt_demo/demo/fastapi_endpoint.xml
+++ b/fastapi_auth_jwt_demo/demo/fastapi_endpoint.xml
@@ -5,5 +5,6 @@
         <field name="app">auth_jwt_demo</field>
         <field name="root_path">/fastapi_auth_jwt_demo</field>
         <field name="user_id" ref="fastapi.my_demo_app_user" />
+        <field name="auth_jwt_validator_id" ref="auth_jwt_demo.demo_validator" />
     </record>
 </odoo>

--- a/fastapi_auth_jwt_demo/models/fastapi_endpoint.py
+++ b/fastapi_auth_jwt_demo/models/fastapi_endpoint.py
@@ -16,6 +16,7 @@ class FastapiEndpoint(models.Model):
         selection_add=[(APP_NAME, "Auth JWT Demo Endpoint")],
         ondelete={APP_NAME: "cascade"},
     )
+    auth_jwt_validator_id = fields.Many2one("auth.jwt.validator")
 
     @api.model
     def _get_fastapi_routers(self):

--- a/fastapi_auth_jwt_demo/readme/CONTRIBUTORS.rst
+++ b/fastapi_auth_jwt_demo/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+Mohamed Alkobrosli <alkobroslymohamed@gmail.com>

--- a/fastapi_auth_jwt_demo/static/description/index.html
+++ b/fastapi_auth_jwt_demo/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -379,7 +379,8 @@ the JWT validators used are those from <tt class="docutils literal">auth_jwt_dem
 <li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
 <li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
 <li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-4">Maintainers</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -400,10 +401,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
+<div class="section" id="contributors">
+<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
+<p>Mohamed Alkobrosli &lt;<a class="reference external" href="mailto:alkobroslymohamed&#64;gmail.com">alkobroslymohamed&#64;gmail.com</a>&gt;</p>
+</div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-4">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/fastapi_auth_jwt_demo/views/fastapi_endpoint_demo.xml
+++ b/fastapi_auth_jwt_demo/views/fastapi_endpoint_demo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 ACSONE SA/NV
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL). -->
+<odoo>
+
+    <record model="ir.ui.view" id="fastapi_endpoint_demo_jwt_form_view">
+        <field name="name">fastapi.endpoint.demo.jwt.form</field>
+        <field name="model">fastapi.endpoint</field>
+        <field name="inherit_id" ref="fastapi.fastapi_endpoint_form_view" />
+        <field name="arch" type="xml">
+                <span name="configuration" position="after">
+                    <group
+                    name="jwt_demo_app_configuration"
+                    title="Configuration"
+                    attrs="{'invisible': [('app', '!=', 'auth_jwt_demo')]}"
+                >
+                        <field
+                        name="auth_jwt_validator_id"
+                        attrs="{'required': [('app', '=', 'auth_jwt_demo')]}"
+                    />
+                    </group>
+                </span>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The demo module is supposed to use JWT authentication, but the JWT authentication is only defined in the shopinvader demo app.

I had to define and connect the many2one field for the validator, which is supposed to be created by the auth_jwt_demo dependency.