### PR TITLE
[17.0][FIX] fastapi: partner env for tests

### DIFF
--- a/fastapi/tests/common.py
+++ b/fastapi/tests/common.py
@@ -127,6 +127,7 @@ class FastAPITransactionCase(TransactionCase):
             or self.default_fastapi_authenticated_partner
             or self.env["res.partner"]
         )
+        partner = partner.with_env(env)
         if partner and authenticated_partner_impl in dependencies:
             raise ValueError(
                 "You cannot provide an override for the authenticated_partner_impl "


### PR DESCRIPTION
`partner` record leaks default env and even if you specify `default_fastapi_running_user` to be custom user, when running tests, running env will still have default (superuser), which makes testing outcomes very different than you might expect.

Setting `partner` to use env with specified user, makes sure it won't leak from there.