### PR TITLE
[16.0][fix] fastapi: init inner_exception properly

### DIFF
--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -13,6 +13,11 @@ from .error_handlers import convert_exception_to_status_body
 class FastApiDispatcher(Dispatcher):
     routing_type = "fastapi"
 
+    def __init__(self, request):
+        super().__init__(request)
+        # Store exception to later raise it in the dispatch method if needed
+        self.inner_exception = None
+
     @classmethod
     def is_compatible_with(cls, request):
         return True
@@ -47,7 +52,6 @@ class FastApiDispatcher(Dispatcher):
     def _make_response(self, status_mapping, headers_tuple, content):
         self.status = status_mapping[:3]
         self.headers = dict(headers_tuple)
-        self.inner_exception = None
         # in case of exception, the method asgi_done_callback of the
         # ASGIResponder will trigger an "a2wsgi.error" event with the exception
         # instance stored in a tuple with the type of the exception and the traceback.


### PR DESCRIPTION
It looks to me that if the app does not yield anything for the response you might encour into an attribute error as the attribute won't be defined yet.

In general, the init method sounds like a better place for shared attributes.

Fixes #487