### PR TITLE
[16.0][IMP] base_rest: if method call result is already an werkzeug.Respons…

### DIFF
--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -4,6 +4,7 @@
 
 import logging
 
+from werkzeug import Response
 from werkzeug.exceptions import NotFound
 
 from odoo.http import request
@@ -160,6 +161,8 @@ class BaseRestService(AbstractComponent):
         else:
             res = method(*args, secure_params)
         self._log_call(method, params, secure_params, res)
+        if isinstance(res, Response):
+            return res
         return self._prepare_response(method, res)
 
     def _validator_delete(self):


### PR DESCRIPTION
…e, it's returned as is (no provessing by the response object

fw-porr of #320