### PR TITLE
[IMP] base_rest_pydantic: compatibility pydantic v2 and pydantic v1

### DIFF
--- a/base_rest_pydantic/__manifest__.py
+++ b/base_rest_pydantic/__manifest__.py
@@ -15,7 +15,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "pydantic<2",
+            "pydantic",
         ]
     },
 }

--- a/base_rest_pydantic/restapi.py
+++ b/base_rest_pydantic/restapi.py
@@ -6,7 +6,7 @@ from odoo.exceptions import UserError
 
 from odoo.addons.base_rest import restapi
 
-from pydantic import BaseModel, ValidationError, validate_model
+from pydantic.v1 import BaseModel, ValidationError, validate_model
 
 
 def replace_ref_in_schema(item, original_schema):

--- a/base_rest_pydantic/tests/test_from_params.py
+++ b/base_rest_pydantic/tests/test_from_params.py
@@ -7,7 +7,7 @@ import mock
 from odoo.exceptions import UserError
 from odoo.tests.common import SavepointCase
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from .. import restapi
 

--- a/base_rest_pydantic/tests/test_response.py
+++ b/base_rest_pydantic/tests/test_response.py
@@ -6,7 +6,7 @@ import mock
 
 from odoo.tests.common import SavepointCase
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from .. import restapi
 


### PR DESCRIPTION
Makes possible to use pydantic v1 features with pydantic v2 installed.

Note:

- not possible on base_rest_demo because module use both pydantic and extendable_pydantic
- trick not working with fastapi, but need to investigate why