### PR TITLE
[FIX] base_rest: restoring the component_database provoked fails with other modules

### DIFF
--- a/base_rest/tests/common.py
+++ b/base_rest/tests/common.py
@@ -70,6 +70,9 @@ class RestServiceRegistryCase(ComponentRegistryCase):
         db_name = get_db_name()
 
         # makes the test component registry available for the db name
+        class_or_instance._original_component_databases = _component_databases.get(
+            db_name
+        )
         _component_databases[db_name] = class_or_instance.comp_registry
 
         # makes the test service registry available for the db name
@@ -145,7 +148,7 @@ class RestServiceRegistryCase(ComponentRegistryCase):
             class_or_instance._controller_children_classes
         )
         db_name = get_db_name()
-        _component_databases[db_name] = class_or_instance._original_components
+        _component_databases[db_name] = class_or_instance._original_component_databases
         _rest_services_databases[
             db_name
         ] = class_or_instance._original_services_registry


### PR DESCRIPTION
In this case, I found that if we tried to test rest_framework and connector_event at the same time, the following error was raised:

```
2025-02-14 22:56:45,874 1 CRITICAL devel odoo.service.server: Failed to initialize database `devel`. 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1323, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/opt/odoo/custom/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 373, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 305, in load_module_graph
    module.write({'state': 'installed', 'latest_version': ver})
  File "/opt/odoo/auto/addons/component_event/models/base.py", line 112, in write
    self._event("on_record_write").notify(record, fields=fields)
  File "/opt/odoo/auto/addons/component_event/models/base.py", line 70, in _event
    if not comp_registry or not comp_registry.ready:
AttributeError: 'collections.defaultdict' object has no attribute 'ready'
```

The main reason was to recreate the _component_database with something that we had the copy applied, transforming it to a defaultdict.