### PR TITLE
[FIX] Using Optional from typing instead of | operation

### DIFF
--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -57,7 +57,9 @@ def authenticated_partner_env(
 
 
 def optionally_authenticated_partner_env(
-    partner: Annotated[Optional[Partner], Depends(optionally_authenticated_partner_impl)],
+    partner: Annotated[
+        Optional[Partner], Depends(optionally_authenticated_partner_impl)
+    ],
     env: Annotated[Environment, Depends(odoo_env)],
 ) -> Environment:
     """Return an environment with the authenticated partner id in the context if
@@ -85,7 +87,9 @@ def authenticated_partner(
 
 
 def optionally_authenticated_partner(
-    partner: Annotated[Optional[Partner], Depends(optionally_authenticated_partner_impl)],
+    partner: Annotated[
+        Optional[Partner], Depends(optionally_authenticated_partner_impl)
+    ],
     partner_env: Annotated[Environment, Depends(optionally_authenticated_partner_env)],
 ) -> Optional[Partner]:
     """If you need to get access to the authenticated partner if the call is

--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -1,7 +1,7 @@
 # Copyright 2022 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
 
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Optional
 
 from odoo.api import Environment
 from odoo.exceptions import AccessDenied
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from .models.fastapi_endpoint import FastapiEndpoint
 
 
-def company_id() -> int | None:
+def company_id() -> Optional[int]:
     """This method may be overriden by the FastAPI app to set the allowed company
     in the Odoo env of the endpoint. By default, the company defined on the
     endpoint record is used.
@@ -27,7 +27,7 @@ def company_id() -> int | None:
     return None
 
 
-def odoo_env(company_id: Annotated[int | None, Depends(company_id)]) -> Environment:
+def odoo_env(company_id: Annotated[Optional[int], Depends(company_id)]) -> Environment:
     env = odoo_env_ctx.get()
     if company_id is not None:
         env = env(context=dict(env.context, allowed_company_ids=[company_id]))
@@ -43,7 +43,7 @@ def authenticated_partner_impl() -> Partner:
     See the fastapi_endpoint_demo for an example"""
 
 
-def optionally_authenticated_partner_impl() -> Partner | None:
+def optionally_authenticated_partner_impl() -> Optional[Partner]:
     """This method has to be overriden when you create your fastapi app
     and you need to get an optional authenticated partner into your endpoint.
     """
@@ -57,7 +57,7 @@ def authenticated_partner_env(
 
 
 def optionally_authenticated_partner_env(
-    partner: Annotated[Partner | None, Depends(optionally_authenticated_partner_impl)],
+    partner: Annotated[Optional[Partner], Depends(optionally_authenticated_partner_impl)],
     env: Annotated[Environment, Depends(odoo_env)],
 ) -> Environment:
     """Return an environment with the authenticated partner id in the context if
@@ -85,9 +85,9 @@ def authenticated_partner(
 
 
 def optionally_authenticated_partner(
-    partner: Annotated[Partner | None, Depends(optionally_authenticated_partner_impl)],
+    partner: Annotated[Optional[Partner], Depends(optionally_authenticated_partner_impl)],
     partner_env: Annotated[Environment, Depends(optionally_authenticated_partner_env)],
-) -> Partner | None:
+) -> Optional[Partner]:
     """If you need to get access to the authenticated partner if the call is
     authenticated, you can add a dependency into the endpoint definition on this
     method.
@@ -155,7 +155,7 @@ def fastapi_endpoint(
 
 def accept_language(
     accept_language: Annotated[
-        str | None,
+        Optional[str],
         Header(
             alias="Accept-Language",
             description="The Accept-Language header is used to specify the language "


### PR DESCRIPTION
## Context:

- I got a dockerfile like:

```dockerfile
FROM odoo:16.0

USER root

COPY ./rest-framework /mnt/extra-addons/rest-framework

COPY ./server-auth /mnt/extra-addons/server-auth

COPY ./web-api /mnt/extra-addons/web-api

RUN apt-get update && apt-get install -y python3-pip

RUN python3 -m pip install --upgrade pip

RUN pip install -r /mnt/extra-addons/rest-framework/requirements.txt

RUN pip install -r /mnt/extra-addons/server-auth/requirements.txt

RUN pip install -r /mnt/extra-addons/web-api/requirements.txt

USER odoo
```
- Build docker image from file, running image as an Odoo container

- Install FastAPI module and meet an error:

```python
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 1658, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 1686, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 1890, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "<decorator-gen-77>", line 2, in button_immediate_install
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_module.py", line 74, in check_and_log
    return method(self, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_module.py", line 478, in button_immediate_install
    return self._button_immediate_function(self.env.registry[self._name].button_install)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_module.py", line 602, in _button_immediate_function
    registry = modules.registry.Registry.new(self._cr.dbname, update_module=True)
  File "<decorator-gen-16>", line 2, in new
  File "/usr/lib/python3/dist-packages/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 373, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 189, in load_module_graph
    load_openerp_module(package.name)
  File "/usr/lib/python3/dist-packages/odoo/modules/module.py", line 471, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/mnt/extra-addons/rest-framework/fastapi/__init__.py", line 1, in <module>
    from . import models
  File "/mnt/extra-addons/rest-framework/fastapi/models/__init__.py", line 1, in <module>
    from .fastapi_endpoint import FastapiEndpoint
  File "/mnt/extra-addons/rest-framework/fastapi/models/fastapi_endpoint.py", line 17, in <module>
    from .. import dependencies
  File "/mnt/extra-addons/rest-framework/fastapi/dependencies.py", line 22, in <module>
    def company_id() -> int | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPCError@http://localhost/web/assets/22-6b01176/web.assets_backend.min.js:998:274
    makeErrorFromResponse@http://localhost/web/assets/22-6b01176/web.assets_backend.min.js:1002:163
    jsonrpc/promise</<@http://localhost/web/assets/22-6b01176/web.assets_backend.min.js:1010:34
    
```

## Reason
turn outs, Odoo:16.0 container is using Python 3.9.2 where | operand is not yet working

```bash
$ python3 --version
Python 3.9.2
```

## Fix
instead of using something like:
```python
... -> int | None
```
we should use something like:
```python
from typing import Optional

... -> Optional[int]
```
for python 3.9 compatible
