### PR TITLE
[16.0] [FIX] fastapi Headers may have multiple keys

### DIFF
--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -51,7 +51,7 @@ class FastApiDispatcher(Dispatcher):
 
     def _make_response(self, status_mapping, headers_tuple, content):
         self.status = status_mapping[:3]
-        self.headers = dict(headers_tuple)
+        self.headers = headers_tuple
         # in case of exception, the method asgi_done_callback of the
         # ASGIResponder will trigger an "a2wsgi.error" event with the exception
         # instance stored in a tuple with the type of the exception and the traceback.


### PR DESCRIPTION
As per [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) and [RFC9651](https://www.rfc-editor.org/rfc/rfc9651.html)

> Multiple message-header fields with the same field-name MAY be present in a message

As [werkzeug.wrappers.Response](https://werkzeug.palletsprojects.com/en/stable/wrappers/#werkzeug.wrappers.Response) expect a dict or a list of (key, value) there's no need to cast to dict