### PR TITLE
[14.0][FIX] base_rest_pydantic: fix `_` being overridden in the `to_response` function

### DIFF
--- a/base_rest_pydantic/restapi.py
+++ b/base_rest_pydantic/restapi.py
@@ -43,12 +43,13 @@ class PydanticModel(restapi.RestMethodParam):
             raise UserError(_("BadRequest %s") % ve.json(indent=0))
 
     def to_response(self, service, result):
-        # do we really need to validate the instance????
         json_dict = result.dict()
+        # The instance might have been created bypassing validation,
+        # so we need to validate it when building the response
         to_validate = (
             json_dict if not result.__config__.orm_mode else result.dict(by_alias=True)
         )
-        *_, validation_error = validate_model(self._model_cls, to_validate)
+        *_ignored, validation_error = validate_model(self._model_cls, to_validate)
         if validation_error:
             raise SystemError(_("Invalid Response %s") % validation_error)
         return json_dict

--- a/base_rest_pydantic/tests/test_response.py
+++ b/base_rest_pydantic/tests/test_response.py
@@ -40,3 +40,11 @@ class TestPydantic(SavepointCase):
         res = self._to_response_list(instances)
         self.assertEqual(len(res), 2)
         self.assertSetEqual({r["name"] for r in res}, {"Instance 1", "Instance 2"})
+
+    def test_to_response_fail(self):
+        class Model1(BaseModel):
+            name: str
+
+        instance = Model1.construct()
+        with self.assertRaisesRegex(SystemError, "Invalid Response"):
+            self._to_response(instance)


### PR DESCRIPTION
A `TypeError: 'list' object is not callable` error was raised when there was a `validation_error`. 
This is due to the fact that `_` was reassigned as a list and then we tried to called `_("Invalid Response %s")`.