### PR TITLE
[18.0][FWP] fastapi: multiple ports from 16.0

### DIFF
--- a/.oca/oca-port/blacklist/fastapi.json
+++ b/.oca/oca-port/blacklist/fastapi.json
@@ -1,0 +1,10 @@
+{
+  "pull_requests": {
+    "orphaned_commits": "(auto) Nothing to port from PR #",
+    "OCA/rest-framework#291": "already ported",
+    "OCA/rest-framework#360": "already ported",
+    "OCA/rest-framework#431": "(auto) Nothing to port from PR #431",
+    "OCA/rest-framework#440": "(auto) Nothing to port from PR #440",
+    "OCA/rest-framework#476": "(auto) Nothing to port from PR #476"
+  }
+}

--- a/base_rest_auth_api_key/README.rst
+++ b/base_rest_auth_api_key/README.rst
@@ -28,9 +28,9 @@ Base Rest Auth Api Key
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-
-This technical addon extend `base_rest` to add the support for auth_api_key
-authentication mechanism into the generated openapi documentation.
+This technical addon extend base_rest to add the support for
+auth_api_key authentication mechanism into the generated openapi
+documentation.
 
 **Table of contents**
 
@@ -51,17 +51,17 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * ACSONE SA/NV
 
 Contributors
-~~~~~~~~~~~~
+------------
 
-* Laurent Mignon <laurent.mignon@acsone.eu>
+- Laurent Mignon <laurent.mignon@acsone.eu>
 
 Maintainers
-~~~~~~~~~~~
+-----------
 
 This module is maintained by the OCA.
 

--- a/base_rest_auth_api_key/readme/CONTRIBUTORS.md
+++ b/base_rest_auth_api_key/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Laurent Mignon \<<laurent.mignon@acsone.eu>\>

--- a/base_rest_auth_api_key/readme/CONTRIBUTORS.rst
+++ b/base_rest_auth_api_key/readme/CONTRIBUTORS.rst
@@ -1,1 +1,0 @@
-* Laurent Mignon <laurent.mignon@acsone.eu>

--- a/base_rest_auth_api_key/readme/DESCRIPTION.md
+++ b/base_rest_auth_api_key/readme/DESCRIPTION.md
@@ -1,0 +1,3 @@
+This technical addon extend base_rest to add the support for
+auth_api_key authentication mechanism into the generated openapi
+documentation.

--- a/base_rest_auth_api_key/readme/DESCRIPTION.rst
+++ b/base_rest_auth_api_key/readme/DESCRIPTION.rst
@@ -1,3 +1,0 @@
-
-This technical addon extend `base_rest` to add the support for auth_api_key
-authentication mechanism into the generated openapi documentation.

--- a/base_rest_auth_api_key/static/description/index.html
+++ b/base_rest_auth_api_key/static/description/index.html
@@ -370,8 +370,9 @@ ul.auto-toc {
 !! source digest: sha256:fbb98424eace411d826bacf3ca3a8fac0c195873026870ef999be5b96aef0ee5
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/rest-framework/tree/18.0/base_rest_auth_api_key"><img alt="OCA/rest-framework" src="https://img.shields.io/badge/github-OCA%2Frest--framework-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/rest-framework-18-0/rest-framework-18-0-base_rest_auth_api_key"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/rest-framework&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This technical addon extend <cite>base_rest</cite> to add the support for auth_api_key
-authentication mechanism into the generated openapi documentation.</p>
+<p>This technical addon extend base_rest to add the support for
+auth_api_key authentication mechanism into the generated openapi
+documentation.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -14,6 +14,11 @@ from .pools import fastapi_app_pool
 class FastApiDispatcher(Dispatcher):
     routing_type = "fastapi"
 
+    def __init__(self, request):
+        super().__init__(request)
+        # Store exception to later raise it in the dispatch method if needed
+        self.inner_exception = None
+
     @classmethod
     def is_compatible_with(cls, request):
         return True
@@ -47,7 +52,6 @@ class FastApiDispatcher(Dispatcher):
     def _make_response(self, status_mapping, headers_tuple, content):
         self.status = status_mapping[:3]
         self.headers = dict(headers_tuple)
-        self.inner_exception = None
         # in case of exception, the method asgi_done_callback of the
         # ASGIResponder will trigger an "a2wsgi.error" event with the exception
         # instance stored in a tuple with the type of the exception and the traceback.

--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -52,6 +52,7 @@ class FastApiDispatcher(Dispatcher):
     def _make_response(self, status_mapping, headers_tuple, content):
         self.status = status_mapping[:3]
         self.headers = headers_tuple
+        self.inner_exception = None
         # in case of exception, the method asgi_done_callback of the
         # ASGIResponder will trigger an "a2wsgi.error" event with the exception
         # instance stored in a tuple with the type of the exception and the traceback.

--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -51,7 +51,7 @@ class FastApiDispatcher(Dispatcher):
 
     def _make_response(self, status_mapping, headers_tuple, content):
         self.status = status_mapping[:3]
-        self.headers = dict(headers_tuple)
+        self.headers = headers_tuple
         # in case of exception, the method asgi_done_callback of the
         # ASGIResponder will trigger an "a2wsgi.error" event with the exception
         # instance stored in a tuple with the type of the exception and the traceback.


### PR DESCRIPTION
Port of the following PRs from 16.0 to 18.0:
- #476
- #488
- #504

The following PRs have been blacklisted:
- #291: (auto) Nothing to port from PR #291
- #360: (auto) Nothing to port from PR #360
- #431: (auto) Nothing to port from PR #431
- #440: (auto) Nothing to port from PR #440
- #476: (auto) Nothing to port from PR #476
