### PR TITLE
[16.0][FIX]base_rest: Fix rest controllers inheritance

### DIFF
--- a/base_rest/controllers/main.py
+++ b/base_rest/controllers/main.py
@@ -96,13 +96,6 @@ class RestController(Controller):
 
     @classmethod
     def __init_subclass__(cls):
-        if (
-            "RestController" in globals()
-            and RestController in cls.__bases__
-            and Controller not in cls.__bases__
-        ):
-            # Ensure that Controller's __init_subclass__ kicks in.
-            cls.__bases__ += (Controller,)
         super().__init_subclass__()
         if "RestController" not in globals() or not any(
             issubclass(b, RestController) for b in cls.__bases__

--- a/base_rest_demo/tests/test_controller.py
+++ b/base_rest_demo/tests/test_controller.py
@@ -18,20 +18,15 @@ class TestController(CommonCase):
         # at the end of the start process, our tow controllers must into the
         # controller registered
         controllers = Controller.children_classes.get("base_rest_demo", [])
-
-        self.assertIn(
-            BaseRestDemoPrivateApiController,
-            controllers,
+        self.assertTrue(
+            any([issubclass(x, BaseRestDemoPrivateApiController) for x in controllers])
         )
-        self.assertIn(
-            BaseRestDemoPublicApiController,
-            controllers,
+        self.assertTrue(
+            any([issubclass(x, BaseRestDemoPublicApiController) for x in controllers])
         )
-        self.assertIn(
-            BaseRestDemoNewApiController,
-            controllers,
+        self.assertTrue(
+            any([issubclass(x, BaseRestDemoNewApiController) for x in controllers])
         )
-        self.assertIn(
-            BaseRestDemoJwtApiController,
-            controllers,
+        self.assertTrue(
+            any([issubclass(x, BaseRestDemoJwtApiController) for x in controllers])
         )


### PR DESCRIPTION
The `__init_subclass__` inheritance is causing problems in 16, the part of the code removed was necessary in 14 due to the controller registration process, in 16 this changed a lot and the `build_controllers` function dont need this.

Steps to reproduce:
Create 2 databases with base_rest_demo module installed, and log-level=debug. Go to database selector and change from one database to another several times to force the routing map generation.

Without this change you will see as every time you change from one database to another, the execution time is bigger, and its creating a rest controller for module odoo, with a duplicity of inheritance every time you recreated the routing map.

> odoo.addons.base_rest.controllers.main: Added rest controller {'root_path': '/base_rest_demo_api/new_api/', 'collection_name': 'base.rest.demo.new_api.services', 'controller_class': <class 'odoo.http.BaseRestDemoNewApiController (extended by BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic, BaseRestDemoNewApiControllerPartner, BaseRestDemoNewApiControllerPartner_Pydantic)'>} for module odoo 
