### PR TITLE
[16.0][FIX]fastapi: temporary fix to an incompatibility with the `endpoint_route_handler` module

### DIFF
--- a/fastapi/models/fastapi_endpoint.py
+++ b/fastapi/models/fastapi_endpoint.py
@@ -136,7 +136,14 @@ class FastapiEndpoint(models.Model):
         return res
 
     def action_sync_registry(self):
-        self.filtered(lambda e: not e.registry_sync).write({"registry_sync": True})
+        endpoints = self.filtered(lambda e: not e.registry_sync)
+        endpoints.write({"registry_sync": True})
+        # This ugly thing solves https://github.com/OCA/rest-framework/issues/391
+        # Basically the first endpoint to be synched cannot be accessed until another
+        # endpoint is synched too
+        if len(endpoints) == 1:
+            endpoints.registry_sync = False
+            endpoints.registry_sync = True
 
     def _handle_route_updates(self, vals):
         observed_fields = [self._routing_impacting_fields(), self._fastapi_app_fields()]


### PR DESCRIPTION
This PR is a temporary fix for https://github.com/OCA/rest-framework/issues/391 until the other module gets taken care of