### PR TITLE
[17.0] [FIX] fastapi: Running User Rule Domain

### DIFF
--- a/fastapi/security/ir_rule+acl.xml
+++ b/fastapi/security/ir_rule+acl.xml
@@ -39,7 +39,7 @@
         <field name="model_id" ref="base.model_res_partner" />
         <field
             name="domain_force"
-        > ['|', ('user_id', '=', user.id), ('id', '=', authenticated_partner_id)]</field>
+        > ['|', ('user_ids', '=', user.id), ('id', '=', authenticated_partner_id)]</field>
         <field name="groups" eval="[(4, ref('group_fastapi_endpoint_runner'))]" />
     </record>
 


### PR DESCRIPTION
Currently, the res.partner rule "fastapi: Running User Rule" filters records using the user_id field (Salesperson) instead of the user_ids field (Users).

![image](https://github.com/user-attachments/assets/9a5408fa-e014-4101-8ea1-358c8c928ba7)

Since the authenticated_partner_id context can be empty, the rule becomes too restrictive and may deny access to the running user, which defeats the purpose it was designed for.

T-8323