### PR TITLE
[16.0][FIX] fastapi: Flush before exiting Fastapi environment

### DIFF
--- a/fastapi/fastapi_dispatcher.py
+++ b/fastapi/fastapi_dispatcher.py
@@ -115,5 +115,10 @@ class FastApiDispatcher(Dispatcher):
         token = odoo_env_ctx.set(env)
         try:
             yield
+            # Flush here to ensure all pending computations are being executed with
+            #  authenticated fastapi user before exiting this context manager, as it
+            #  would otherwise be done using the public user on the commit of the DB
+            #  cursor, what could potentially lead to inconsistencies or AccessError.
+            env.flush_all()
         finally:
             odoo_env_ctx.reset(token)


### PR DESCRIPTION
As the fastapi dispatcher is altering the public request's environment before calling the endpoint, it will reuse the same DB cursor from this environment.

Therefore, if fields are being marked to be recomputed during the execution of the fastapi endpoint, these will not be recomputed until the cursor is being commited, what happens when we are not anymore authenticated through as fastapi user. This means the recomputation of computed fields will be executed with the public user, what could potentially lead to inconsistencies or result in an AccessError.

By calling flush before exiting the contextmanager yielding the altered Odoo environment, we ensure all the pending computations are executed while being authenticated with the fastapi user which must have more access rights than the public user.

backport of #538