### PR TITLE
[IMP] pydantic: moving from pydantic v1 to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,9 @@ jobs:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
             name: test with Odoo
-            pydantic2: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
-            name: test with OCB and pydantic > 2.0
+            name: test with OCB
             makepot: "true"
-            pydantic2: "true"
-          - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
-            name: test with OCB and pydantic < 2.0
-            exclude: "fastapi"
     services:
       postgres:
         image: postgres:12.0
@@ -54,8 +49,6 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
-    env:
-      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,12 +61,6 @@ jobs:
         run: manifestoo -d . check-dev-status --default-dev-status=Beta
       - name: Initialize test db
         run: oca_init_test_database
-      - name: Ensure pydantic version < 2
-        run: pip install "pydantic<2.0"
-        if: ${{ matrix.pydantic2 != 'true' }}
-      - name: Ensure pydantic version > 2
-        run: pip install "pydantic>2.0"
-        if: ${{ matrix.pydantic2 == 'true' }}
       - name: Run tests
         run: oca_run_tests
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,14 @@ jobs:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
             name: test with Odoo
+            pydantic2: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
-            name: test with OCB
+            name: test with OCB and pydantic > 2.0
             makepot: "true"
+            pydantic2: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
+            name: test with OCB and pydantic < 2.0
+            exclude: "fastapi"
     services:
       postgres:
         image: postgres:12.0
@@ -49,6 +54,8 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -61,6 +68,12 @@ jobs:
         run: manifestoo -d . check-dev-status --default-dev-status=Beta
       - name: Initialize test db
         run: oca_init_test_database
+      - name: Ensure pydantic version < 2
+        run: pip install "pydantic<2.0"
+        if: ${{ matrix.pydantic2 != 'true' }}
+      - name: Ensure pydantic version > 2
+        run: pip install "pydantic>2.0"
+        if: ${{ matrix.pydantic2 == 'true' }}
       - name: Run tests
         run: oca_run_tests
       - uses: codecov/codecov-action@v4

--- a/graphql_base/README.rst
+++ b/graphql_base/README.rst
@@ -44,9 +44,9 @@ Usage
 
 To use this module, you need to
 
--  create your graphene schema
--  create your controller to expose your GraphQL endpoint, and
-   optionally a GraphiQL IDE.
+- create your graphene schema
+- create your controller to expose your GraphQL endpoint, and optionally
+  a GraphiQL IDE.
 
 This module does not attempt to expose the whole Odoo object model. This
 could be the purpose of another module based on this one. We believe
@@ -56,12 +56,12 @@ exposed and needs to be tested when upgrading Odoo.
 
 To start working with this module, we recommend the following approach:
 
--  Learn `GraphQL basics <https://graphql.org/learn/>`__
--  Learn `graphene <https://graphene-python.org/>`__, the python library
-   used to create GraphQL schemas and resolvers.
--  Examine the ``graphql_demo`` module in this repo, copy it, adapt the
-   controller to suit your needs (routes, authentication methods).
--  Start building your own schema and resolver.
+- Learn `GraphQL basics <https://graphql.org/learn/>`__
+- Learn `graphene <https://graphene-python.org/>`__, the python library
+  used to create GraphQL schemas and resolvers.
+- Examine the ``graphql_demo`` module in this repo, copy it, adapt the
+  controller to suit your needs (routes, authentication methods).
+- Start building your own schema and resolver.
 
 Building your schema
 --------------------
@@ -71,11 +71,11 @@ The schema can be built using native graphene types. An
 convenience. It is a graphene ``ObjectType`` with a default attribute
 resolver which:
 
--  converts False to None (except for Boolean types), to avoid Odoo's
-   weird ``False`` strings being rendered as json ``"false"``;
--  adds the user timezone to Datetime fields;
--  raises an error if an attribute is absent to avoid field name typing
-   errors.
+- converts False to None (except for Boolean types), to avoid Odoo's
+  weird ``False`` strings being rendered as json ``"false"``;
+- adds the user timezone to Datetime fields;
+- raises an error if an attribute is absent to avoid field name typing
+  errors.
 
 Creating GraphQL controllers
 ----------------------------

--- a/graphql_base/__manifest__.py
+++ b/graphql_base/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/rest-framework",
     "depends": ["base"],
     "data": ["views/graphiql.xml"],
-    "external_dependencies": {"python": ["graphene", "graphql_server"]},
+    "external_dependencies": {"python": ["graphene", "graphql_server==3.0.0b7"]},
     "development_status": "Production/Stable",
     "maintainers": ["sbidoul"],
     "installable": True,

--- a/graphql_base/static/description/index.html
+++ b/graphql_base/static/description/index.html
@@ -396,8 +396,8 @@ controller. An example is available in the <tt class="docutils literal">graphql_
 <p>To use this module, you need to</p>
 <ul class="simple">
 <li>create your graphene schema</li>
-<li>create your controller to expose your GraphQL endpoint, and
-optionally a GraphiQL IDE.</li>
+<li>create your controller to expose your GraphQL endpoint, and optionally
+a GraphiQL IDE.</li>
 </ul>
 <p>This module does not attempt to expose the whole Odoo object model. This
 could be the purpose of another module based on this one. We believe
@@ -433,24 +433,24 @@ errors.</li>
 <tt class="docutils literal">odoo.addons.graphql_base.GraphQLControllerMixin</tt> class to help you
 build GraphQL controllers providing GraphiQL and/or GraphQL endpoints.</p>
 <pre class="code python literal-block">
-<span class="kn">from</span> <span class="nn">odoo</span> <span class="kn">import</span> <span class="n">http</span><span class="w">
-</span><span class="kn">from</span> <span class="nn">odoo.addons.graphql_base</span> <span class="kn">import</span> <span class="n">GraphQLControllerMixin</span><span class="w">
+<span class="kn">from</span><span class="w"> </span><span class="nn">odoo</span><span class="w"> </span><span class="kn">import</span> <span class="n">http</span><span class="w">
+</span><span class="kn">from</span><span class="w"> </span><span class="nn">odoo.addons.graphql_base</span><span class="w"> </span><span class="kn">import</span> <span class="n">GraphQLControllerMixin</span><span class="w">
 
-</span><span class="kn">from</span> <span class="nn">..schema</span> <span class="kn">import</span> <span class="n">schema</span><span class="w">
+</span><span class="kn">from</span><span class="w"> </span><span class="nn">..schema</span><span class="w"> </span><span class="kn">import</span> <span class="n">schema</span><span class="w">
 
 
-</span><span class="k">class</span> <span class="nc">GraphQLController</span><span class="p">(</span><span class="n">http</span><span class="o">.</span><span class="n">Controller</span><span class="p">,</span> <span class="n">GraphQLControllerMixin</span><span class="p">):</span><span class="w">
+</span><span class="k">class</span><span class="w"> </span><span class="nc">GraphQLController</span><span class="p">(</span><span class="n">http</span><span class="o">.</span><span class="n">Controller</span><span class="p">,</span> <span class="n">GraphQLControllerMixin</span><span class="p">):</span><span class="w">
 
 </span>    <span class="c1"># The GraphiQL route, providing an IDE for developers</span><span class="w">
 </span>    <span class="nd">&#64;http</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s2">&quot;/graphiql/demo&quot;</span><span class="p">,</span> <span class="n">auth</span><span class="o">=</span><span class="s2">&quot;user&quot;</span><span class="p">)</span><span class="w">
-</span>    <span class="k">def</span> <span class="nf">graphiql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span><span class="w"> </span><span class="nf">graphiql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
 </span>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_handle_graphiql_request</span><span class="p">(</span><span class="n">schema</span><span class="p">)</span><span class="w">
 
 </span>    <span class="c1"># The graphql route, for applications.</span><span class="w">
 </span>    <span class="c1"># Note csrf=False: you may want to apply extra security</span><span class="w">
 </span>    <span class="c1"># (such as origin restrictions) to this route.</span><span class="w">
 </span>    <span class="nd">&#64;http</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s2">&quot;/graphql/demo&quot;</span><span class="p">,</span> <span class="n">auth</span><span class="o">=</span><span class="s2">&quot;user&quot;</span><span class="p">,</span> <span class="n">csrf</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span><span class="w">
-</span>    <span class="k">def</span> <span class="nf">graphql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span><span class="w"> </span><span class="nf">graphql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
 </span>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_handle_graphql_request</span><span class="p">(</span><span class="n">schema</span><span class="p">)</span>
 </pre>
 </div>

--- a/pydantic/README.rst
+++ b/pydantic/README.rst
@@ -29,13 +29,13 @@ Pydantic
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This addon provides a utility method that can be used to map odoo record
-to a `Pydantic model <https://pydantic-docs.helpmanual.io/>`__.
+to a `Pydantic model <https://docs.pydantic.dev/>`__.
 
 If you need to make your Pydantic models extendable at runtime, takes a
 look at the python package
 `extendable-pydantic <https://pypi.org/project/extendable_pydantic/>`__
-and the odoo addon
-`extendable <https://github.com/acsone/odoo-addon-extendable>`__
+and the `odoo addon
+extendable <https://pypi.org/project/odoo-addon-extendable>`__
 
 **Table of contents**
 
@@ -47,9 +47,30 @@ Usage
 
 To support pydantic models that map to Odoo models, Pydantic model
 instances can be created from arbitrary odoo model instances by mapping
-fields from odoo models to fields defined by the pydantic model. To ease
-the mapping, the addon provide a utility class
-odoo.addons.pydantic.utils.GenericOdooGetter.
+fields from odoo models to fields defined by the pydantic model.
+
+To ease the mapping, the addon provide 2 utility classes:
+
+- Using ``pydantic>2.0``,
+  ``odoo.addons.pydantic.utils.PydanticOdooBaseModel``:
+
+.. code:: python
+
+   from odoo.addons.pydantic.utils import PydanticOdooBaseModel
+
+
+   class Group(PydanticOdooBaseModel):
+       name: str
+
+   class UserInfo(PydanticOdooBaseModel):
+       name: str
+       groups: List[Group] = pydantic.Field(alias="groups_id")
+
+   user = self.env.user
+   user_info = UserInfo.from_orm(user)
+
+- Using ``pydantic<2.0``,
+  ``odoo.addons.pydantic.utils.GenericOdooGetter``:
 
 .. code:: python
 
@@ -74,9 +95,8 @@ odoo.addons.pydantic.utils.GenericOdooGetter.
    user = self.env.user
    user_info = UserInfo.from_orm(user)
 
-See the official `Pydantic
-documentation <https://pydantic-docs.helpmanual.io/>`__ to discover all
-the available functionalities.
+See the official `Pydantic documentation <https://docs.pydantic.dev/>`__
+to discover all the available functionalities.
 
 Known issues / Roadmap
 ======================
@@ -108,8 +128,9 @@ Authors
 Contributors
 ------------
 
--  Laurent Mignon <laurent.mignon@acsone.eu>
--  Tris Doan <tridm@trobz.com>
+- Laurent Mignon <laurent.mignon@acsone.eu>
+- Tris Doan <tridm@trobz.com>
+- Pierre Verkest <pierre@verkest.fr>
 
 Maintainers
 -----------

--- a/pydantic/README.rst
+++ b/pydantic/README.rst
@@ -29,7 +29,7 @@ Pydantic
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This addon provides a utility method that can be used to map odoo record
-to a `Pydantic model <https://docs.pydantic.dev/>`__.
+to a `Pydantic model (>= v2) <https://docs.pydantic.dev/>`__.
 
 If you need to make your Pydantic models extendable at runtime, takes a
 look at the python package
@@ -49,10 +49,8 @@ To support pydantic models that map to Odoo models, Pydantic model
 instances can be created from arbitrary odoo model instances by mapping
 fields from odoo models to fields defined by the pydantic model.
 
-To ease the mapping, the addon provide 2 utility classes:
-
-- Using ``pydantic>2.0``,
-  ``odoo.addons.pydantic.utils.PydanticOdooBaseModel``:
+To ease the mapping, the addon provide an utility class (using
+``pydantic>2.0``) ``odoo.addons.pydantic.utils.PydanticOdooBaseModel``:
 
 .. code:: python
 
@@ -65,32 +63,6 @@ To ease the mapping, the addon provide 2 utility classes:
    class UserInfo(PydanticOdooBaseModel):
        name: str
        groups: List[Group] = pydantic.Field(alias="groups_id")
-
-   user = self.env.user
-   user_info = UserInfo.from_orm(user)
-
-- Using ``pydantic<2.0``,
-  ``odoo.addons.pydantic.utils.GenericOdooGetter``:
-
-.. code:: python
-
-   import pydantic
-   from odoo.addons.pydantic import utils
-
-   class Group(pydantic.BaseModel):
-       name: str
-
-       class Config:
-           orm_mode = True
-           getter_dict = utils.GenericOdooGetter
-
-   class UserInfo(pydantic.BaseModel):
-       name: str
-       groups: List[Group] = pydantic.Field(alias="groups_id")
-
-       class Config:
-           orm_mode = True
-           getter_dict = utils.GenericOdooGetter
 
    user = self.env.user
    user_info = UserInfo.from_orm(user)

--- a/pydantic/__manifest__.py
+++ b/pydantic/__manifest__.py
@@ -15,7 +15,7 @@
     "data": [],
     "demo": [],
     "external_dependencies": {
-        "python": ["pydantic", "contextvars", "typing-extensions"]
+        "python": ["pydantic>=2.0", "contextvars", "typing-extensions"]
     },
     "installable": True,
 }

--- a/pydantic/readme/CONTRIBUTORS.md
+++ b/pydantic/readme/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 - Laurent Mignon \<<laurent.mignon@acsone.eu>\>
 - Tris Doan \<<tridm@trobz.com>\>
+- Pierre Verkest \<<pierre@verkest.fr>\>

--- a/pydantic/readme/DESCRIPTION.md
+++ b/pydantic/readme/DESCRIPTION.md
@@ -1,5 +1,5 @@
 This addon provides a utility method that can be used to map odoo record
-to a [Pydantic model](https://docs.pydantic.dev/).
+to a [Pydantic model (>= v2)](https://docs.pydantic.dev/).
 
 If you need to make your Pydantic models extendable at runtime, takes a
 look at the python package

--- a/pydantic/readme/DESCRIPTION.md
+++ b/pydantic/readme/DESCRIPTION.md
@@ -1,8 +1,7 @@
 This addon provides a utility method that can be used to map odoo record
-to a [Pydantic model](https://pydantic-docs.helpmanual.io/).
+to a [Pydantic model](https://docs.pydantic.dev/).
 
 If you need to make your Pydantic models extendable at runtime, takes a
 look at the python package
 [extendable-pydantic](https://pypi.org/project/extendable_pydantic/) and
-the odoo addon
-[extendable](https://github.com/acsone/odoo-addon-extendable)
+the [odoo addon extendable](https://pypi.org/project/odoo-addon-extendable)

--- a/pydantic/readme/USAGE.md
+++ b/pydantic/readme/USAGE.md
@@ -1,8 +1,28 @@
 To support pydantic models that map to Odoo models, Pydantic model
 instances can be created from arbitrary odoo model instances by mapping
-fields from odoo models to fields defined by the pydantic model. To ease
-the mapping, the addon provide a utility class
-odoo.addons.pydantic.utils.GenericOdooGetter.
+fields from odoo models to fields defined by the pydantic model. 
+
+
+To ease the mapping, the addon provide 2 utility classes:
+
+* Using `pydantic>2.0`, `odoo.addons.pydantic.utils.PydanticOdooBaseModel`:
+
+``` python
+from odoo.addons.pydantic.utils import PydanticOdooBaseModel
+
+
+class Group(PydanticOdooBaseModel):
+    name: str
+
+class UserInfo(PydanticOdooBaseModel):
+    name: str
+    groups: List[Group] = pydantic.Field(alias="groups_id")
+
+user = self.env.user
+user_info = UserInfo.from_orm(user)
+```
+
+* Using `pydantic<2.0`, `odoo.addons.pydantic.utils.GenericOdooGetter`:
 
 ``` python
 import pydantic
@@ -28,5 +48,5 @@ user_info = UserInfo.from_orm(user)
 ```
 
 See the official [Pydantic
-documentation](https://pydantic-docs.helpmanual.io/) to discover all the
+documentation](https://docs.pydantic.dev/) to discover all the
 available functionalities.

--- a/pydantic/readme/USAGE.md
+++ b/pydantic/readme/USAGE.md
@@ -3,9 +3,7 @@ instances can be created from arbitrary odoo model instances by mapping
 fields from odoo models to fields defined by the pydantic model. 
 
 
-To ease the mapping, the addon provide 2 utility classes:
-
-* Using `pydantic>2.0`, `odoo.addons.pydantic.utils.PydanticOdooBaseModel`:
+To ease the mapping, the addon provide an utility class (using `pydantic>2.0`) `odoo.addons.pydantic.utils.PydanticOdooBaseModel`:
 
 ``` python
 from odoo.addons.pydantic.utils import PydanticOdooBaseModel
@@ -17,31 +15,6 @@ class Group(PydanticOdooBaseModel):
 class UserInfo(PydanticOdooBaseModel):
     name: str
     groups: List[Group] = pydantic.Field(alias="groups_id")
-
-user = self.env.user
-user_info = UserInfo.from_orm(user)
-```
-
-* Using `pydantic<2.0`, `odoo.addons.pydantic.utils.GenericOdooGetter`:
-
-``` python
-import pydantic
-from odoo.addons.pydantic import utils
-
-class Group(pydantic.BaseModel):
-    name: str
-
-    class Config:
-        orm_mode = True
-        getter_dict = utils.GenericOdooGetter
-
-class UserInfo(pydantic.BaseModel):
-    name: str
-    groups: List[Group] = pydantic.Field(alias="groups_id")
-
-    class Config:
-        orm_mode = True
-        getter_dict = utils.GenericOdooGetter
 
 user = self.env.user
 user_info = UserInfo.from_orm(user)

--- a/pydantic/static/description/index.html
+++ b/pydantic/static/description/index.html
@@ -371,7 +371,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/rest-framework/tree/17.0/pydantic"><img alt="OCA/rest-framework" src="https://img.shields.io/badge/github-OCA%2Frest--framework-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/rest-framework-17-0/rest-framework-17-0-pydantic"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/rest-framework&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This addon provides a utility method that can be used to map odoo record
-to a <a class="reference external" href="https://docs.pydantic.dev/">Pydantic model</a>.</p>
+to a <a class="reference external" href="https://docs.pydantic.dev/">Pydantic model (&gt;= v2)</a>.</p>
 <p>If you need to make your Pydantic models extendable at runtime, takes a
 look at the python package
 <a class="reference external" href="https://pypi.org/project/extendable_pydantic/">extendable-pydantic</a>
@@ -396,11 +396,8 @@ extendable</a></p>
 <p>To support pydantic models that map to Odoo models, Pydantic model
 instances can be created from arbitrary odoo model instances by mapping
 fields from odoo models to fields defined by the pydantic model.</p>
-<p>To ease the mapping, the addon provide 2 utility classes:</p>
-<ul class="simple">
-<li>Using <tt class="docutils literal">pydantic&gt;2.0</tt>,
-<tt class="docutils literal">odoo.addons.pydantic.utils.PydanticOdooBaseModel</tt>:</li>
-</ul>
+<p>To ease the mapping, the addon provide an utility class (using
+<tt class="docutils literal">pydantic&gt;2.0</tt>) <tt class="docutils literal">odoo.addons.pydantic.utils.PydanticOdooBaseModel</tt>:</p>
 <pre class="code python literal-block">
 <span class="kn">from</span><span class="w"> </span><span class="nn">odoo.addons.pydantic.utils</span><span class="w"> </span><span class="kn">import</span> <span class="n">PydanticOdooBaseModel</span><span class="w">
 
@@ -411,32 +408,6 @@ fields from odoo models to fields defined by the pydantic model.</p>
 </span><span class="k">class</span><span class="w"> </span><span class="nc">UserInfo</span><span class="p">(</span><span class="n">PydanticOdooBaseModel</span><span class="p">):</span><span class="w">
 </span>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="w">
 </span>    <span class="n">groups</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n">Group</span><span class="p">]</span> <span class="o">=</span> <span class="n">pydantic</span><span class="o">.</span><span class="n">Field</span><span class="p">(</span><span class="n">alias</span><span class="o">=</span><span class="s2">&quot;groups_id&quot;</span><span class="p">)</span><span class="w">
-
-</span><span class="n">user</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">env</span><span class="o">.</span><span class="n">user</span><span class="w">
-</span><span class="n">user_info</span> <span class="o">=</span> <span class="n">UserInfo</span><span class="o">.</span><span class="n">from_orm</span><span class="p">(</span><span class="n">user</span><span class="p">)</span>
-</pre>
-<ul class="simple">
-<li>Using <tt class="docutils literal">pydantic&lt;2.0</tt>,
-<tt class="docutils literal">odoo.addons.pydantic.utils.GenericOdooGetter</tt>:</li>
-</ul>
-<pre class="code python literal-block">
-<span class="kn">import</span><span class="w"> </span><span class="nn">pydantic</span><span class="w">
-</span><span class="kn">from</span><span class="w"> </span><span class="nn">odoo.addons.pydantic</span><span class="w"> </span><span class="kn">import</span> <span class="n">utils</span><span class="w">
-
-</span><span class="k">class</span><span class="w"> </span><span class="nc">Group</span><span class="p">(</span><span class="n">pydantic</span><span class="o">.</span><span class="n">BaseModel</span><span class="p">):</span><span class="w">
-</span>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="w">
-
-</span>    <span class="k">class</span><span class="w"> </span><span class="nc">Config</span><span class="p">:</span><span class="w">
-</span>        <span class="n">orm_mode</span> <span class="o">=</span> <span class="kc">True</span><span class="w">
-</span>        <span class="n">getter_dict</span> <span class="o">=</span> <span class="n">utils</span><span class="o">.</span><span class="n">GenericOdooGetter</span><span class="w">
-
-</span><span class="k">class</span><span class="w"> </span><span class="nc">UserInfo</span><span class="p">(</span><span class="n">pydantic</span><span class="o">.</span><span class="n">BaseModel</span><span class="p">):</span><span class="w">
-</span>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="w">
-</span>    <span class="n">groups</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n">Group</span><span class="p">]</span> <span class="o">=</span> <span class="n">pydantic</span><span class="o">.</span><span class="n">Field</span><span class="p">(</span><span class="n">alias</span><span class="o">=</span><span class="s2">&quot;groups_id&quot;</span><span class="p">)</span><span class="w">
-
-</span>    <span class="k">class</span><span class="w"> </span><span class="nc">Config</span><span class="p">:</span><span class="w">
-</span>        <span class="n">orm_mode</span> <span class="o">=</span> <span class="kc">True</span><span class="w">
-</span>        <span class="n">getter_dict</span> <span class="o">=</span> <span class="n">utils</span><span class="o">.</span><span class="n">GenericOdooGetter</span><span class="w">
 
 </span><span class="n">user</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">env</span><span class="o">.</span><span class="n">user</span><span class="w">
 </span><span class="n">user_info</span> <span class="o">=</span> <span class="n">UserInfo</span><span class="o">.</span><span class="n">from_orm</span><span class="p">(</span><span class="n">user</span><span class="p">)</span>

--- a/pydantic/static/description/index.html
+++ b/pydantic/static/description/index.html
@@ -371,12 +371,12 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/rest-framework/tree/17.0/pydantic"><img alt="OCA/rest-framework" src="https://img.shields.io/badge/github-OCA%2Frest--framework-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/rest-framework-17-0/rest-framework-17-0-pydantic"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/rest-framework&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This addon provides a utility method that can be used to map odoo record
-to a <a class="reference external" href="https://pydantic-docs.helpmanual.io/">Pydantic model</a>.</p>
+to a <a class="reference external" href="https://docs.pydantic.dev/">Pydantic model</a>.</p>
 <p>If you need to make your Pydantic models extendable at runtime, takes a
 look at the python package
 <a class="reference external" href="https://pypi.org/project/extendable_pydantic/">extendable-pydantic</a>
-and the odoo addon
-<a class="reference external" href="https://github.com/acsone/odoo-addon-extendable">extendable</a></p>
+and the <a class="reference external" href="https://pypi.org/project/odoo-addon-extendable">odoo addon
+extendable</a></p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -395,34 +395,54 @@ and the odoo addon
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
 <p>To support pydantic models that map to Odoo models, Pydantic model
 instances can be created from arbitrary odoo model instances by mapping
-fields from odoo models to fields defined by the pydantic model. To ease
-the mapping, the addon provide a utility class
-odoo.addons.pydantic.utils.GenericOdooGetter.</p>
+fields from odoo models to fields defined by the pydantic model.</p>
+<p>To ease the mapping, the addon provide 2 utility classes:</p>
+<ul class="simple">
+<li>Using <tt class="docutils literal">pydantic&gt;2.0</tt>,
+<tt class="docutils literal">odoo.addons.pydantic.utils.PydanticOdooBaseModel</tt>:</li>
+</ul>
 <pre class="code python literal-block">
-<span class="kn">import</span> <span class="nn">pydantic</span><span class="w">
-</span><span class="kn">from</span> <span class="nn">odoo.addons.pydantic</span> <span class="kn">import</span> <span class="n">utils</span><span class="w">
+<span class="kn">from</span><span class="w"> </span><span class="nn">odoo.addons.pydantic.utils</span><span class="w"> </span><span class="kn">import</span> <span class="n">PydanticOdooBaseModel</span><span class="w">
 
-</span><span class="k">class</span> <span class="nc">Group</span><span class="p">(</span><span class="n">pydantic</span><span class="o">.</span><span class="n">BaseModel</span><span class="p">):</span><span class="w">
+
+</span><span class="k">class</span><span class="w"> </span><span class="nc">Group</span><span class="p">(</span><span class="n">PydanticOdooBaseModel</span><span class="p">):</span><span class="w">
 </span>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="w">
 
-</span>    <span class="k">class</span> <span class="nc">Config</span><span class="p">:</span><span class="w">
-</span>        <span class="n">orm_mode</span> <span class="o">=</span> <span class="kc">True</span><span class="w">
-</span>        <span class="n">getter_dict</span> <span class="o">=</span> <span class="n">utils</span><span class="o">.</span><span class="n">GenericOdooGetter</span><span class="w">
-
-</span><span class="k">class</span> <span class="nc">UserInfo</span><span class="p">(</span><span class="n">pydantic</span><span class="o">.</span><span class="n">BaseModel</span><span class="p">):</span><span class="w">
+</span><span class="k">class</span><span class="w"> </span><span class="nc">UserInfo</span><span class="p">(</span><span class="n">PydanticOdooBaseModel</span><span class="p">):</span><span class="w">
 </span>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="w">
 </span>    <span class="n">groups</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n">Group</span><span class="p">]</span> <span class="o">=</span> <span class="n">pydantic</span><span class="o">.</span><span class="n">Field</span><span class="p">(</span><span class="n">alias</span><span class="o">=</span><span class="s2">&quot;groups_id&quot;</span><span class="p">)</span><span class="w">
 
-</span>    <span class="k">class</span> <span class="nc">Config</span><span class="p">:</span><span class="w">
+</span><span class="n">user</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">env</span><span class="o">.</span><span class="n">user</span><span class="w">
+</span><span class="n">user_info</span> <span class="o">=</span> <span class="n">UserInfo</span><span class="o">.</span><span class="n">from_orm</span><span class="p">(</span><span class="n">user</span><span class="p">)</span>
+</pre>
+<ul class="simple">
+<li>Using <tt class="docutils literal">pydantic&lt;2.0</tt>,
+<tt class="docutils literal">odoo.addons.pydantic.utils.GenericOdooGetter</tt>:</li>
+</ul>
+<pre class="code python literal-block">
+<span class="kn">import</span><span class="w"> </span><span class="nn">pydantic</span><span class="w">
+</span><span class="kn">from</span><span class="w"> </span><span class="nn">odoo.addons.pydantic</span><span class="w"> </span><span class="kn">import</span> <span class="n">utils</span><span class="w">
+
+</span><span class="k">class</span><span class="w"> </span><span class="nc">Group</span><span class="p">(</span><span class="n">pydantic</span><span class="o">.</span><span class="n">BaseModel</span><span class="p">):</span><span class="w">
+</span>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="w">
+
+</span>    <span class="k">class</span><span class="w"> </span><span class="nc">Config</span><span class="p">:</span><span class="w">
+</span>        <span class="n">orm_mode</span> <span class="o">=</span> <span class="kc">True</span><span class="w">
+</span>        <span class="n">getter_dict</span> <span class="o">=</span> <span class="n">utils</span><span class="o">.</span><span class="n">GenericOdooGetter</span><span class="w">
+
+</span><span class="k">class</span><span class="w"> </span><span class="nc">UserInfo</span><span class="p">(</span><span class="n">pydantic</span><span class="o">.</span><span class="n">BaseModel</span><span class="p">):</span><span class="w">
+</span>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="w">
+</span>    <span class="n">groups</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n">Group</span><span class="p">]</span> <span class="o">=</span> <span class="n">pydantic</span><span class="o">.</span><span class="n">Field</span><span class="p">(</span><span class="n">alias</span><span class="o">=</span><span class="s2">&quot;groups_id&quot;</span><span class="p">)</span><span class="w">
+
+</span>    <span class="k">class</span><span class="w"> </span><span class="nc">Config</span><span class="p">:</span><span class="w">
 </span>        <span class="n">orm_mode</span> <span class="o">=</span> <span class="kc">True</span><span class="w">
 </span>        <span class="n">getter_dict</span> <span class="o">=</span> <span class="n">utils</span><span class="o">.</span><span class="n">GenericOdooGetter</span><span class="w">
 
 </span><span class="n">user</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">env</span><span class="o">.</span><span class="n">user</span><span class="w">
 </span><span class="n">user_info</span> <span class="o">=</span> <span class="n">UserInfo</span><span class="o">.</span><span class="n">from_orm</span><span class="p">(</span><span class="n">user</span><span class="p">)</span>
 </pre>
-<p>See the official <a class="reference external" href="https://pydantic-docs.helpmanual.io/">Pydantic
-documentation</a> to discover all
-the available functionalities.</p>
+<p>See the official <a class="reference external" href="https://docs.pydantic.dev/">Pydantic documentation</a>
+to discover all the available functionalities.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
@@ -453,6 +473,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
 <li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
+<li>Pierre Verkest &lt;<a class="reference external" href="mailto:pierre&#64;verkest.fr">pierre&#64;verkest.fr</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/pydantic/tests/__init__.py
+++ b/pydantic/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_pydantic_generic_odoo_getter

--- a/pydantic/tests/test_pydantic_generic_odoo_getter.py
+++ b/pydantic/tests/test_pydantic_generic_odoo_getter.py
@@ -1,0 +1,206 @@
+import datetime
+from unittest import skipIf
+
+from odoo import fields
+from odoo.tests import TransactionCase
+
+from pydantic import BaseModel, Field
+
+from ..utils import PYDANTIC_V2
+
+if PYDANTIC_V2:
+    from ..utils import PydanticOdooBaseModel as PydanticOrmBaseModel
+
+else:
+    from ..utils import GenericOdooGetter
+
+    class PydanticOrmBaseModel(BaseModel):
+        class Config:
+            orm_mode = True
+            getter_dict = GenericOdooGetter
+
+
+class OdooBaseModel(PydanticOrmBaseModel):
+    id: int
+
+
+class PartnerModel(OdooBaseModel):
+    name: str
+    date: datetime.date | None = None
+
+
+class UserFlatModel(OdooBaseModel):
+    partner_id: int = Field(title="Partner")
+
+
+class GroupModel(OdooBaseModel):
+    name: str
+
+
+class UserModel(OdooBaseModel):
+    partner: PartnerModel = Field(title="Partner", alias="partner_id")
+
+
+class UserDetailsModel(UserModel):
+    groups: list[GroupModel] = Field(alias="groups_id")
+    action_id: OdooBaseModel | None = None
+    signature: str | None = None
+    active: bool | None = None
+    share: bool | None = None
+    write_date: datetime.datetime
+
+
+class CommonPydanticCase(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_demo = cls.env.ref("base.user_demo")
+        cls.user_demo.action_id = False
+        cls.user_demo.signature = False
+        cls.user_demo.share = False
+
+
+@skipIf(PYDANTIC_V2, "Ignore because Pydantic >= 2.0 is installed")
+class TestGenericOdooGetterPydanticV1Case(CommonPydanticCase):
+    def test_user_model_serialization(self):
+        self.user_demo.partner_id.date = None
+        self.assertEqual(
+            UserModel.from_orm(self.user_demo).dict(),
+            {
+                "id": self.user_demo.id,
+                "partner": {
+                    "id": self.user_demo.partner_id.id,
+                    "name": self.user_demo.partner_id.name,
+                    "date": None,
+                },
+            },
+        )
+
+    def test_user_model_serialization_date(self):
+        self.user_demo.partner_id.date = fields.Date.today()
+        self.assertEqual(
+            UserModel.from_orm(self.user_demo).partner.date,
+            self.user_demo.partner_id.date,
+        )
+
+    def test_user_model_details_serialization_datetime(self):
+        user_demo = self.user_demo.with_context(tz="Asia/Tokyo")
+        self.assertEqual(
+            UserDetailsModel.from_orm(user_demo).write_date,
+            fields.Datetime.context_timestamp(user_demo, user_demo.write_date),
+        )
+        self.assertNotEqual(
+            UserDetailsModel.from_orm(user_demo).write_date.tzinfo,
+            fields.Datetime.context_timestamp(
+                self.user_demo, user_demo.write_date
+            ).tzinfo,
+        )
+
+    def test_user_details_model_serialization(self):
+        self.assertEqual(
+            UserDetailsModel.from_orm(self.user_demo).dict(),
+            {
+                "id": self.user_demo.id,
+                "partner": {
+                    "id": self.user_demo.partner_id.id,
+                    "name": self.user_demo.partner_id.name,
+                    "date": None,
+                },
+                "groups": [
+                    {
+                        "id": group.id,
+                        "name": group.name,
+                    }
+                    for group in self.user_demo.groups_id
+                ],
+                "action_id": None,
+                "signature": None,
+                "active": True,
+                "share": False,
+                "write_date": fields.Datetime.context_timestamp(
+                    self.user_demo, self.user_demo.write_date
+                ),
+            },
+        )
+
+    def test_user_flat_model_serialization(self):
+        self.assertEqual(
+            UserFlatModel.from_orm(self.user_demo).dict(),
+            {
+                "id": self.user_demo.id,
+                "partner_id": self.user_demo.partner_id.id,
+            },
+        )
+
+
+@skipIf(not PYDANTIC_V2, "Ignore because Pydantic < 2.0 is installed")
+class TestGenericOdooGetterPydanticV2Case(CommonPydanticCase):
+    def test_user_model_serialization(self):
+        self.user_demo.partner_id.date = None
+        self.assertEqual(
+            UserModel.model_validate(self.user_demo, from_attributes=True).model_dump(),
+            {
+                "id": self.user_demo.id,
+                "partner": {
+                    "id": self.user_demo.partner_id.id,
+                    "name": self.user_demo.partner_id.name,
+                    "date": None,
+                },
+            },
+        )
+
+    def test_user_model_serialization_date(self):
+        self.user_demo.partner_id.date = fields.Date.today()
+        self.assertEqual(
+            UserModel.model_validate(self.user_demo).partner.date,
+            self.user_demo.partner_id.date,
+        )
+
+    def test_user_model_details_serialization_datetime(self):
+        user_demo = self.user_demo.with_context(tz="Asia/Tokyo")
+        self.assertEqual(
+            UserDetailsModel.model_validate(user_demo).write_date,
+            fields.Datetime.context_timestamp(user_demo, user_demo.write_date),
+        )
+        self.assertNotEqual(
+            UserDetailsModel.model_validate(user_demo).write_date.tzinfo,
+            fields.Datetime.context_timestamp(
+                self.user_demo, user_demo.write_date
+            ).tzinfo,
+        )
+
+    def test_user_details_model_serialization(self):
+        self.assertEqual(
+            UserDetailsModel.model_validate(self.user_demo).model_dump(),
+            {
+                "id": self.user_demo.id,
+                "partner": {
+                    "id": self.user_demo.partner_id.id,
+                    "name": self.user_demo.partner_id.name,
+                    "date": None,
+                },
+                "groups": [
+                    {
+                        "id": group.id,
+                        "name": group.name,
+                    }
+                    for group in self.user_demo.groups_id
+                ],
+                "action_id": None,
+                "signature": None,
+                "active": True,
+                "share": False,
+                "write_date": fields.Datetime.context_timestamp(
+                    self.user_demo, self.user_demo.write_date
+                ),
+            },
+        )
+
+    def test_user_flat_model_serialization(self):
+        self.assertEqual(
+            UserFlatModel.model_validate(self.user_demo).model_dump(),
+            {
+                "id": self.user_demo.id,
+                "partner_id": self.user_demo.partner_id.id,
+            },
+        )

--- a/pydantic/tests/test_pydantic_generic_odoo_getter.py
+++ b/pydantic/tests/test_pydantic_generic_odoo_getter.py
@@ -1,23 +1,11 @@
 import datetime
-from unittest import skipIf
 
 from odoo import fields
 from odoo.tests import TransactionCase
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from ..utils import PYDANTIC_V2
-
-if PYDANTIC_V2:
-    from ..utils import PydanticOdooBaseModel as PydanticOrmBaseModel
-
-else:
-    from ..utils import GenericOdooGetter
-
-    class PydanticOrmBaseModel(BaseModel):
-        class Config:
-            orm_mode = True
-            getter_dict = GenericOdooGetter
+from ..utils import PydanticOdooBaseModel as PydanticOrmBaseModel
 
 
 class OdooBaseModel(PydanticOrmBaseModel):
@@ -60,80 +48,6 @@ class CommonPydanticCase(TransactionCase):
         cls.user_demo.share = False
 
 
-@skipIf(PYDANTIC_V2, "Ignore because Pydantic >= 2.0 is installed")
-class TestGenericOdooGetterPydanticV1Case(CommonPydanticCase):
-    def test_user_model_serialization(self):
-        self.user_demo.partner_id.date = None
-        self.assertEqual(
-            UserModel.from_orm(self.user_demo).dict(),
-            {
-                "id": self.user_demo.id,
-                "partner": {
-                    "id": self.user_demo.partner_id.id,
-                    "name": self.user_demo.partner_id.name,
-                    "date": None,
-                },
-            },
-        )
-
-    def test_user_model_serialization_date(self):
-        self.user_demo.partner_id.date = fields.Date.today()
-        self.assertEqual(
-            UserModel.from_orm(self.user_demo).partner.date,
-            self.user_demo.partner_id.date,
-        )
-
-    def test_user_model_details_serialization_datetime(self):
-        user_demo = self.user_demo.with_context(tz="Asia/Tokyo")
-        self.assertEqual(
-            UserDetailsModel.from_orm(user_demo).write_date,
-            fields.Datetime.context_timestamp(user_demo, user_demo.write_date),
-        )
-        self.assertNotEqual(
-            UserDetailsModel.from_orm(user_demo).write_date.tzinfo,
-            fields.Datetime.context_timestamp(
-                self.user_demo, user_demo.write_date
-            ).tzinfo,
-        )
-
-    def test_user_details_model_serialization(self):
-        self.assertEqual(
-            UserDetailsModel.from_orm(self.user_demo).dict(),
-            {
-                "id": self.user_demo.id,
-                "partner": {
-                    "id": self.user_demo.partner_id.id,
-                    "name": self.user_demo.partner_id.name,
-                    "date": None,
-                },
-                "groups": [
-                    {
-                        "id": group.id,
-                        "name": group.name,
-                    }
-                    for group in self.user_demo.groups_id
-                ],
-                "action_id": None,
-                "signature": None,
-                "active": True,
-                "share": False,
-                "write_date": fields.Datetime.context_timestamp(
-                    self.user_demo, self.user_demo.write_date
-                ),
-            },
-        )
-
-    def test_user_flat_model_serialization(self):
-        self.assertEqual(
-            UserFlatModel.from_orm(self.user_demo).dict(),
-            {
-                "id": self.user_demo.id,
-                "partner_id": self.user_demo.partner_id.id,
-            },
-        )
-
-
-@skipIf(not PYDANTIC_V2, "Ignore because Pydantic < 2.0 is installed")
 class TestGenericOdooGetterPydanticV2Case(CommonPydanticCase):
     def test_user_model_serialization(self):
         self.user_demo.partner_id.date = None
@@ -203,4 +117,19 @@ class TestGenericOdooGetterPydanticV2Case(CommonPydanticCase):
                 "id": self.user_demo.id,
                 "partner_id": self.user_demo.partner_id.id,
             },
+        )
+
+    def test_not_an_odoo_record(self):
+        user = UserDetailsModel(
+            id=666,
+            partner_id={"id": 66, "name": "test"},
+            groups_id=[{"id": 33, "name": "group 1"}],
+            action_id={"id": 55},
+            signature=None,
+            active=True,
+            share=False,
+            write_date=fields.Datetime.now(),
+        )
+        self.assertEqual(
+            UserDetailsModel.model_validate(user).model_dump(), user.model_dump()
         )

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -3,134 +3,82 @@
 
 from typing import Any
 
-from packaging.version import Version
-
 from odoo import fields, models
 
-from pydantic import __version__ as pydantic_version
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
-PYDANTIC_V2: bool = Version(pydantic_version) >= Version("2.0")
 
+class PydanticOdooBaseModel(BaseModel):
+    """Pydantic BaseModel for odoo record
 
-if PYDANTIC_V2:
-    from pydantic import (
-        BaseModel,
-        ConfigDict,
-        ValidationInfo,
-        field_validator,
-        model_validator,
+    This aims to help to serialize Odoo record
+    improving behavior like previous version:
+
+    * Avoid False value on non boolean fields
+    * Convert Datetime to Datetime timezone aware
+    * using int type on many2one return the foreign key id
+      (not the odoo record)
+    """
+
+    model_config = ConfigDict(
+        from_attributes=True,
     )
 
-    class PydanticOdooBaseModel(BaseModel):
-        """Pydantic BaseModel for odoo record
+    @classmethod
+    def model_validate(
+        cls,
+        obj: Any,
+        *,
+        context: Any | None = None,
+        **kwargs,
+    ):
+        if context is None:
+            context = {}
 
-        This aims to help to serialize Odoo record
-        improving behavior like previous version:
+        if "odoo_records" not in context:
+            context["odoo_records"] = {}
 
-        * Avoid False value on non boolean fields
-        * Convert Datetime to Datetime timezone aware
-        * if manyone
-
-        """
-
-        model_config = ConfigDict(
-            from_attributes=True,
+        return super().model_validate(
+            obj,
+            context=context,
+            **kwargs,
         )
 
-        @field_validator("*", mode="before")
-        @classmethod
-        def odoo_validator_before(cls, value: Any, info: ValidationInfo):
-            odoo_record = info.config.get("odoo_record")
-            if odoo_record:
-                if info.field_name in odoo_record._fields:
-                    field = odoo_record._fields[info.field_name]
-                    if value is False and field.type != "boolean":
-                        return None
-                    if field.type == "datetime":
-                        # Get the timestamp converted to the client's timezone.
-                        # This call also add the tzinfo into the datetime object
-                        return fields.Datetime.context_timestamp(odoo_record, value)
-                    if field.type == "many2one":
-                        if not value:
-                            return None
-                        if issubclass(cls.__annotations__.get(info.field_name), int):
-                            # if field typing is an integer we return the .id
-                            # (not the odoo record)
-                            return value.id
-            return value
-
-        @model_validator(mode="before")
-        @classmethod
-        def odoo_model_validator(cls, data: Any, info: ValidationInfo) -> Any:
-            info.config["odoo_record"] = (
-                data if isinstance(data, models.BaseModel) else None
-            )
-            return data
-
-else:
-    from pydantic.utils import GetterDict
-
-    class GenericOdooGetter(GetterDict):
-        """A generic GetterDict for Odoo models
-
-        The getter take care of casting one2many and many2many
-        field values to python list to allow the from_orm method from
-        pydantic class to work on odoo models. This getter is to specify
-        into the pydantic config.
-
-        Usage:
-
-        .. code-block:: python
-
-            import pydantic
-            from odoo.addons.pydantic import models, utils
-
-            class Group(models.BaseModel):
-                name: str
-
-                class Config:
-                    orm_mode = True
-                    getter_dict = utils.GenericOdooGetter
-
-            class UserInfo(models.BaseModel):
-                name: str
-                groups: List[Group] = pydantic.Field(alias="groups_id")
-
-                class Config:
-                    orm_mode = True
-                    getter_dict = utils.GenericOdooGetter
-
-            user = self.env.user
-            user_info = UserInfo.from_orm(user)
-
-        To avoid having to repeat the specific configuration required for the
-        `from_orm` method into each pydantic model, "odoo_orm_mode" can be used
-        as parent via the `_inherit` attribute
-
-        """
-
-        def get(self, key: Any, default: Any = None) -> Any:
-            res = getattr(self._obj, key, default)
-            if isinstance(self._obj, models.BaseModel) and key in self._obj._fields:
-                field = self._obj._fields[key]
-                if res is False and field.type != "boolean":
-                    return None
-                if field.type == "date" and not res:
-                    # PV: tests prove that this is useless, I'm wondering if
-                    # there is case where data can be Falsy but not False?
-                    # keeping to avoid regressions
+    @field_validator("*", mode="before")
+    @classmethod
+    def odoo_validator_before(cls, value: Any, info: ValidationInfo):
+        odoo_record = info.context and info.context.get("odoo_records").get(
+            info.config.get("title")
+        )
+        if odoo_record is not None:
+            if info.field_name in odoo_record._fields:
+                field = odoo_record._fields[info.field_name]
+                if value is False and field.type != "boolean":
                     return None
                 if field.type == "datetime":
-                    if not res:
-                        # I'm wondering if there is case where data can be
-                        # Falsy but not False?
-                        # keeping to avoid regressions
-                        return None
                     # Get the timestamp converted to the client's timezone.
                     # This call also add the tzinfo into the datetime object
-                    return fields.Datetime.context_timestamp(self._obj, res)
-                if field.type == "many2one" and not res:
-                    return None
-                if field.type in ["one2many", "many2many"]:
-                    return list(res)
-            return res
+                    return fields.Datetime.context_timestamp(odoo_record, value)
+                if field.type == "many2one":
+                    if not value:
+                        return None
+                    if issubclass(cls.__annotations__.get(info.field_name), int):
+                        # if field typing is an integer we return the .id
+                        # (not the odoo record)
+                        return value.id
+        return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def odoo_model_validator(cls, data: Any, info: ValidationInfo) -> Any:
+        if isinstance(info.context, dict):
+            info.context["odoo_records"][info.config.get("title")] = (
+                data if isinstance(data, models.BaseModel) else None
+            )
+        return data

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -3,66 +3,134 @@
 
 from typing import Any
 
+from packaging.version import Version
+
 from odoo import fields, models
 
-from pydantic.utils import GetterDict
+from pydantic import __version__ as pydantic_version
+
+PYDANTIC_V2: bool = Version(pydantic_version) >= Version("2.0")
 
 
-class GenericOdooGetter(GetterDict):
-    """A generic GetterDict for Odoo models
+if PYDANTIC_V2:
+    from pydantic import (
+        BaseModel,
+        ConfigDict,
+        ValidationInfo,
+        field_validator,
+        model_validator,
+    )
 
-    The getter take care of casting one2many and many2many
-    field values to python list to allow the from_orm method from
-    pydantic class to work on odoo models. This getter is to specify
-    into the pydantic config.
+    class PydanticOdooBaseModel(BaseModel):
+        """Pydantic BaseModel for odoo record
 
-    Usage:
+        This aims to help to serialize Odoo record
+        improving behavior like previous version:
 
-     .. code-block:: python
+        * Avoid False value on non boolean fields
+        * Convert Datetime to Datetime timezone aware
+        * if manyone
 
-        import pydantic
-        from odoo.addons.pydantic import models, utils
+        """
 
-        class Group(models.BaseModel):
-            name: str
+        model_config = ConfigDict(
+            from_attributes=True,
+        )
 
-            class Config:
-                orm_mode = True
-                getter_dict = utils.GenericOdooGetter
+        @field_validator("*", mode="before")
+        @classmethod
+        def odoo_validator_before(cls, value: Any, info: ValidationInfo):
+            odoo_record = info.config.get("odoo_record")
+            if odoo_record:
+                if info.field_name in odoo_record._fields:
+                    field = odoo_record._fields[info.field_name]
+                    if value is False and field.type != "boolean":
+                        return None
+                    if field.type == "datetime":
+                        # Get the timestamp converted to the client's timezone.
+                        # This call also add the tzinfo into the datetime object
+                        return fields.Datetime.context_timestamp(odoo_record, value)
+                    if field.type == "many2one":
+                        if not value:
+                            return None
+                        if issubclass(cls.__annotations__.get(info.field_name), int):
+                            # if field typing is an integer we return the .id
+                            # (not the odoo record)
+                            return value.id
+            return value
 
-        class UserInfo(models.BaseModel):
-            name: str
-            groups: List[Group] = pydantic.Field(alias="groups_id")
+        @model_validator(mode="before")
+        @classmethod
+        def odoo_model_validator(cls, data: Any, info: ValidationInfo) -> Any:
+            info.config["odoo_record"] = (
+                data if isinstance(data, models.BaseModel) else None
+            )
+            return data
 
-            class Config:
-                orm_mode = True
-                getter_dict = utils.GenericOdooGetter
+else:
+    from pydantic.utils import GetterDict
 
-        user = self.env.user
-        user_info = UserInfo.from_orm(user)
+    class GenericOdooGetter(GetterDict):
+        """A generic GetterDict for Odoo models
 
-    To avoid having to repeat the specific configuration required for the
-    `from_orm` method into each pydantic model, "odoo_orm_mode" can be used
-     as parent via the `_inherit` attribute
+        The getter take care of casting one2many and many2many
+        field values to python list to allow the from_orm method from
+        pydantic class to work on odoo models. This getter is to specify
+        into the pydantic config.
 
-    """
+        Usage:
 
-    def get(self, key: Any, default: Any = None) -> Any:
-        res = getattr(self._obj, key, default)
-        if isinstance(self._obj, models.BaseModel) and key in self._obj._fields:
-            field = self._obj._fields[key]
-            if res is False and field.type != "boolean":
-                return None
-            if field.type == "date" and not res:
-                return None
-            if field.type == "datetime":
-                if not res:
+        .. code-block:: python
+
+            import pydantic
+            from odoo.addons.pydantic import models, utils
+
+            class Group(models.BaseModel):
+                name: str
+
+                class Config:
+                    orm_mode = True
+                    getter_dict = utils.GenericOdooGetter
+
+            class UserInfo(models.BaseModel):
+                name: str
+                groups: List[Group] = pydantic.Field(alias="groups_id")
+
+                class Config:
+                    orm_mode = True
+                    getter_dict = utils.GenericOdooGetter
+
+            user = self.env.user
+            user_info = UserInfo.from_orm(user)
+
+        To avoid having to repeat the specific configuration required for the
+        `from_orm` method into each pydantic model, "odoo_orm_mode" can be used
+        as parent via the `_inherit` attribute
+
+        """
+
+        def get(self, key: Any, default: Any = None) -> Any:
+            res = getattr(self._obj, key, default)
+            if isinstance(self._obj, models.BaseModel) and key in self._obj._fields:
+                field = self._obj._fields[key]
+                if res is False and field.type != "boolean":
                     return None
-                # Get the timestamp converted to the client's timezone.
-                # This call also add the tzinfo into the datetime object
-                return fields.Datetime.context_timestamp(self._obj, res)
-            if field.type == "many2one" and not res:
-                return None
-            if field.type in ["one2many", "many2many"]:
-                return list(res)
-        return res
+                if field.type == "date" and not res:
+                    # PV: tests prove that this is useless, I'm wondering if
+                    # there is case where data can be Falsy but not False?
+                    # keeping to avoid regressions
+                    return None
+                if field.type == "datetime":
+                    if not res:
+                        # I'm wondering if there is case where data can be
+                        # Falsy but not False?
+                        # keeping to avoid regressions
+                        return None
+                    # Get the timestamp converted to the client's timezone.
+                    # This call also add the tzinfo into the datetime object
+                    return fields.Datetime.context_timestamp(self._obj, res)
+                if field.type == "many2one" and not res:
+                    return None
+                if field.type in ["one2many", "many2many"]:
+                    return list(res)
+            return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fastapi>=0.110.0
 graphene
 graphql_server
 parse-accept-language
-pydantic
+pydantic>=2.0
 python-multipart
 typing-extensions
 ujson

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ a2wsgi>=1.10.6
 contextvars
 fastapi>=0.110.0
 graphene
-graphql_server
+graphql_server==3.0.0b7
 parse-accept-language
 pydantic>=2.0
 python-multipart


### PR DESCRIPTION
Smothly migrate webservice from pydantic<2.0 using pydantic odoo module to pydantic>2.0 getting the same behaviour retrieves odoo data from Odoo records.


Using this PR to migrate your pydantic models you have to do something this:

* before using `pydantic < "2.0"` your model looks like something like this:
```python

from pydantic import BaseModel

from odoo.addons.pydantic.utils import GenericOdooGetter


class PartnerModel(BaseModel):
    class Config:
        orm_mode = True
        getter_dict = GenericOdooGetter
    
    id: int
    name: str
```
* after using `pydantic > "2.0"` you should subclass `PydanticOdooBaseModel` which set the pydantic model config with the new `from_attributes=True` (aka old orm_mode). Your model will get same behaviour as the previous versions using the `GenericOdooGetter`:

```python
from odoo.addons.pydantic.utils import PydanticOdooBaseModel


class PartnerModel(PydanticOdooBaseModel):

    id: int
    name: str
```
    