### PR TITLE
[FIX] graphql_base: pin graphql-server <3.0.0

### DIFF
--- a/graphql_base/__manifest__.py
+++ b/graphql_base/__manifest__.py
@@ -11,6 +11,9 @@
     "website": "https://github.com/OCA/rest-framework",
     "depends": ["base"],
     "data": ["views/graphiql.xml"],
+    # We place an upper bound on graphql-server because it has undergone a major
+    # change in 3.0.0b8 in Aug 2025. When graphql-server 3 has stabilized we'll need
+    # to update this module to make it compatible with it.
     "external_dependencies": {"python": ["graphene", "graphql-server<3.0.0b8"]},
     "development_status": "Production/Stable",
     "maintainers": ["sbidoul"],

--- a/graphql_base/__manifest__.py
+++ b/graphql_base/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/rest-framework",
     "depends": ["base"],
     "data": ["views/graphiql.xml"],
-    "external_dependencies": {"python": ["graphene", "graphql_server"]},
+    "external_dependencies": {"python": ["graphene", "graphql-server<3.0.0b8"]},
     "development_status": "Production/Stable",
     "maintainers": ["sbidoul"],
     "installable": True,

--- a/graphql_base/static/description/index.html
+++ b/graphql_base/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -433,24 +433,24 @@ default attribute resolver which:</p>
 class to help you build GraphQL controllers providing GraphiQL and/or GraphQL
 endpoints.</p>
 <pre class="code python literal-block">
-<span class="kn">from</span> <span class="nn">odoo</span> <span class="kn">import</span> <span class="n">http</span><span class="w">
-</span><span class="kn">from</span> <span class="nn">odoo.addons.graphql_base</span> <span class="kn">import</span> <span class="n">GraphQLControllerMixin</span><span class="w">
+<span class="kn">from</span><span class="w"> </span><span class="nn">odoo</span><span class="w"> </span><span class="kn">import</span> <span class="n">http</span><span class="w">
+</span><span class="kn">from</span><span class="w"> </span><span class="nn">odoo.addons.graphql_base</span><span class="w"> </span><span class="kn">import</span> <span class="n">GraphQLControllerMixin</span><span class="w">
 
-</span><span class="kn">from</span> <span class="nn">..schema</span> <span class="kn">import</span> <span class="n">schema</span><span class="w">
+</span><span class="kn">from</span><span class="w"> </span><span class="nn">..schema</span><span class="w"> </span><span class="kn">import</span> <span class="n">schema</span><span class="w">
 
 
-</span><span class="k">class</span> <span class="nc">GraphQLController</span><span class="p">(</span><span class="n">http</span><span class="o">.</span><span class="n">Controller</span><span class="p">,</span> <span class="n">GraphQLControllerMixin</span><span class="p">):</span><span class="w">
+</span><span class="k">class</span><span class="w"> </span><span class="nc">GraphQLController</span><span class="p">(</span><span class="n">http</span><span class="o">.</span><span class="n">Controller</span><span class="p">,</span> <span class="n">GraphQLControllerMixin</span><span class="p">):</span><span class="w">
 
 </span>    <span class="c1"># The GraphiQL route, providing an IDE for developers</span><span class="w">
 </span>    <span class="nd">&#64;http</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s2">&quot;/graphiql/demo&quot;</span><span class="p">,</span> <span class="n">auth</span><span class="o">=</span><span class="s2">&quot;user&quot;</span><span class="p">)</span><span class="w">
-</span>    <span class="k">def</span> <span class="nf">graphiql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span><span class="w"> </span><span class="nf">graphiql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
 </span>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_handle_graphiql_request</span><span class="p">(</span><span class="n">schema</span><span class="p">)</span><span class="w">
 
 </span>    <span class="c1"># The graphql route, for applications.</span><span class="w">
 </span>    <span class="c1"># Note csrf=False: you may want to apply extra security</span><span class="w">
 </span>    <span class="c1"># (such as origin restrictions) to this route.</span><span class="w">
 </span>    <span class="nd">&#64;http</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s2">&quot;/graphql/demo&quot;</span><span class="p">,</span> <span class="n">auth</span><span class="o">=</span><span class="s2">&quot;user&quot;</span><span class="p">,</span> <span class="n">csrf</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span><span class="w">
-</span>    <span class="k">def</span> <span class="nf">graphql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span><span class="w"> </span><span class="nf">graphql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
 </span>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_handle_graphql_request</span><span class="p">(</span><span class="n">schema</span><span class="p">)</span>
 </pre>
 </div>
@@ -474,7 +474,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/graphql_base/static/description/index.html
+++ b/graphql_base/static/description/index.html
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -8,11 +9,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -433,24 +433,24 @@ default attribute resolver which:</p>
 class to help you build GraphQL controllers providing GraphiQL and/or GraphQL
 endpoints.</p>
 <pre class="code python literal-block">
-<span class="kn">from</span><span class="w"> </span><span class="nn">odoo</span><span class="w"> </span><span class="kn">import</span> <span class="n">http</span><span class="w">
-</span><span class="kn">from</span><span class="w"> </span><span class="nn">odoo.addons.graphql_base</span><span class="w"> </span><span class="kn">import</span> <span class="n">GraphQLControllerMixin</span><span class="w">
+<span class="kn">from</span> <span class="nn">odoo</span> <span class="kn">import</span> <span class="n">http</span><span class="w">
+</span><span class="kn">from</span> <span class="nn">odoo.addons.graphql_base</span> <span class="kn">import</span> <span class="n">GraphQLControllerMixin</span><span class="w">
 
-</span><span class="kn">from</span><span class="w"> </span><span class="nn">..schema</span><span class="w"> </span><span class="kn">import</span> <span class="n">schema</span><span class="w">
+</span><span class="kn">from</span> <span class="nn">..schema</span> <span class="kn">import</span> <span class="n">schema</span><span class="w">
 
 
-</span><span class="k">class</span><span class="w"> </span><span class="nc">GraphQLController</span><span class="p">(</span><span class="n">http</span><span class="o">.</span><span class="n">Controller</span><span class="p">,</span> <span class="n">GraphQLControllerMixin</span><span class="p">):</span><span class="w">
+</span><span class="k">class</span> <span class="nc">GraphQLController</span><span class="p">(</span><span class="n">http</span><span class="o">.</span><span class="n">Controller</span><span class="p">,</span> <span class="n">GraphQLControllerMixin</span><span class="p">):</span><span class="w">
 
 </span>    <span class="c1"># The GraphiQL route, providing an IDE for developers</span><span class="w">
 </span>    <span class="nd">&#64;http</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s2">&quot;/graphiql/demo&quot;</span><span class="p">,</span> <span class="n">auth</span><span class="o">=</span><span class="s2">&quot;user&quot;</span><span class="p">)</span><span class="w">
-</span>    <span class="k">def</span><span class="w"> </span><span class="nf">graphiql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span> <span class="nf">graphiql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
 </span>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_handle_graphiql_request</span><span class="p">(</span><span class="n">schema</span><span class="p">)</span><span class="w">
 
 </span>    <span class="c1"># The graphql route, for applications.</span><span class="w">
 </span>    <span class="c1"># Note csrf=False: you may want to apply extra security</span><span class="w">
 </span>    <span class="c1"># (such as origin restrictions) to this route.</span><span class="w">
 </span>    <span class="nd">&#64;http</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s2">&quot;/graphql/demo&quot;</span><span class="p">,</span> <span class="n">auth</span><span class="o">=</span><span class="s2">&quot;user&quot;</span><span class="p">,</span> <span class="n">csrf</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span><span class="w">
-</span>    <span class="k">def</span><span class="w"> </span><span class="nf">graphql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
+</span>    <span class="k">def</span> <span class="nf">graphql</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span><span class="w">
 </span>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_handle_graphql_request</span><span class="p">(</span><span class="n">schema</span><span class="p">)</span>
 </pre>
 </div>
@@ -474,9 +474,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ extendable-pydantic>=1.2.0
 extendable>=0.0.4
 fastapi>=0.110.0
 graphene
-graphql_server
+graphql-server<3.0.0b8
 itsdangerous
 jsondiff
 marshmallow


### PR DESCRIPTION
graphql-server 3.0.0 removed HttpQueryError, which breaks graphql_base controller on Odoo 16. 
Pin dependency to <3.0.0 to keep stable behavior.

[Ref: OCA/rest-framework#559](https://github.com/OCA/rest-framework/issues/559)

Task: 4927