### PR TITLE
[FIX][16.0] auth_partner: check if auth_partner.exists()

### DIFF
--- a/auth_partner/models/auth_directory.py
+++ b/auth_partner/models/auth_directory.py
@@ -197,7 +197,7 @@ class AuthDirectory(models.Model):
 
         if (
             obj["action"] != action
-            or not auth_partner
+            or not auth_partner.exists()
             or auth_partner.directory_id != self
         ):
             raise UserError(_("Invalid token"))


### PR DESCRIPTION
browse() will return a pseudo-record.
Use browse().exists() to ensure the record exists.