### PR TITLE
[19.0] Fixed compatibility issues with odoo19 for fastapi

### DIFF
--- a/fastapi/__manifest__.py
+++ b/fastapi/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Odoo FastAPI",
     "summary": """
         Odoo FastAPI endpoint""",
-    "version": "18.0.1.3.0",
+    "version": "19.0.0.0.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["lmignon"],
@@ -30,5 +30,5 @@
         ]
     },
     "development_status": "Beta",
-    "installable": False,
+    "installable": True,
 }

--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Annotated
 from odoo.api import Environment
 from odoo.exceptions import AccessDenied
 
-from odoo.addons.base.models.res_partner import Partner
-from odoo.addons.base.models.res_users import Users
+from odoo.addons.base.models.res_partner import ResPartner
+from odoo.addons.base.models.res_users import ResUsers
 
 from fastapi import Depends, Header, HTTPException, Query, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
@@ -35,7 +35,7 @@ def odoo_env(company_id: Annotated[int | None, Depends(company_id)]) -> Environm
     yield env
 
 
-def authenticated_partner_impl() -> Partner:
+def authenticated_partner_impl() -> ResPartner:
     """This method has to be overriden when you create your fastapi app
     to declare the way your partner will be provided. In some case, this
     partner will come from the authentication mechanism (ex jwt token) in other cases
@@ -43,21 +43,21 @@ def authenticated_partner_impl() -> Partner:
     See the fastapi_endpoint_demo for an example"""
 
 
-def optionally_authenticated_partner_impl() -> Partner | None:
+def optionally_authenticated_partner_impl() -> ResPartner | None:
     """This method has to be overriden when you create your fastapi app
     and you need to get an optional authenticated partner into your endpoint.
     """
 
 
 def authenticated_partner_env(
-    partner: Annotated[Partner, Depends(authenticated_partner_impl)],
+    partner: Annotated[ResPartner, Depends(authenticated_partner_impl)],
 ) -> Environment:
     """Return an environment with the authenticated partner id in the context"""
     return partner.with_context(authenticated_partner_id=partner.id).env
 
 
 def optionally_authenticated_partner_env(
-    partner: Annotated[Partner | None, Depends(optionally_authenticated_partner_impl)],
+    partner: Annotated[ResPartner | None, Depends(optionally_authenticated_partner_impl)],
     env: Annotated[Environment, Depends(odoo_env)],
 ) -> Environment:
     """Return an environment with the authenticated partner id in the context if
@@ -69,9 +69,9 @@ def optionally_authenticated_partner_env(
 
 
 def authenticated_partner(
-    partner: Annotated[Partner, Depends(authenticated_partner_impl)],
+    partner: Annotated[ResPartner, Depends(authenticated_partner_impl)],
     partner_env: Annotated[Environment, Depends(authenticated_partner_env)],
-) -> Partner:
+) -> ResPartner:
     """If you need to get access to the authenticated partner into your
     endpoint, you can add a dependency into the endpoint definition on this
     method.
@@ -85,9 +85,9 @@ def authenticated_partner(
 
 
 def optionally_authenticated_partner(
-    partner: Annotated[Partner | None, Depends(optionally_authenticated_partner_impl)],
+    partner: Annotated[ResPartner | None, Depends(optionally_authenticated_partner_impl)],
     partner_env: Annotated[Environment, Depends(optionally_authenticated_partner_env)],
-) -> Partner | None:
+) -> ResPartner | None:
     """If you need to get access to the authenticated partner if the call is
     authenticated, you can add a dependency into the endpoint definition on this
     method.
@@ -110,7 +110,7 @@ def paging(
 def basic_auth_user(
     credential: Annotated[HTTPBasicCredentials, Depends(HTTPBasic())],
     env: Annotated[Environment, Depends(odoo_env)],
-) -> Users:
+) -> ResUsers:
     username = credential.username
     password = credential.password
     try:
@@ -137,9 +137,9 @@ def basic_auth_user(
 
 
 def authenticated_partner_from_basic_auth_user(
-    user: Annotated[Users, Depends(basic_auth_user)],
+    user: Annotated[ResUsers, Depends(basic_auth_user)],
     env: Annotated[Environment, Depends(odoo_env)],
-) -> Partner:
+) -> ResPartner:
     return env["res.partner"].browse(user.sudo().partner_id.id)
 
 

--- a/fastapi/models/fastapi_endpoint_demo.py
+++ b/fastapi/models/fastapi_endpoint_demo.py
@@ -6,7 +6,7 @@ from odoo import _, api, fields, models
 from odoo.api import Environment
 from odoo.exceptions import ValidationError
 
-from odoo.addons.base.models.res_partner import Partner
+from odoo.addons.base.models.res_partner import ResPartner
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import APIKeyHeader
@@ -90,7 +90,7 @@ def api_key_based_authenticated_partner_impl(
         ),
     ],
     env: Annotated[Environment, Depends(odoo_env)],
-) -> Partner:
+) -> ResPartner:
     """A dummy implementation that look for a user with the same login
     as the provided api key
     """

--- a/fastapi/routers/demo_router.py
+++ b/fastapi/routers/demo_router.py
@@ -14,7 +14,7 @@ from odoo.api import Environment
 from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
 from odoo.service.model import MAX_TRIES_ON_CONCURRENCY_FAILURE
 
-from odoo.addons.base.models.res_partner import Partner
+from odoo.addons.base.models.res_partner import ResPartner
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, status
 from fastapi.responses import JSONResponse
@@ -67,7 +67,7 @@ async def get_lang(env: Annotated[Environment, Depends(odoo_env)]):
 
 @router.get("/demo/who_ami")
 async def who_ami(
-    partner: Annotated[Partner, Depends(authenticated_partner)],
+    partner: Annotated[ResPartner, Depends(authenticated_partner)],
 ) -> DemoUserInfo:
     """Who am I?
 

--- a/fastapi/security/res_groups.xml
+++ b/fastapi/security/res_groups.xml
@@ -11,15 +11,13 @@
     <record id="group_fastapi_user" model="res.groups">
         <field name="name">User</field>
         <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
-        <field name="category_id" ref="module_category_fastapi" />
     </record>
 
     <record id="group_fastapi_manager" model="res.groups">
         <field name="name">Administrator</field>
-        <field name="category_id" ref="module_category_fastapi" />
         <field name="implied_ids" eval="[(4, ref('group_fastapi_user'))]" />
         <field
-            name="users"
+            name="user_ids"
             eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
         />
     </record>
@@ -28,6 +26,5 @@
      the user running the endpoint handlers and performs authentication -->
     <record id="group_fastapi_endpoint_runner" model="res.groups">
         <field name="name">FastAPI Endpoint Runner</field>
-        <field name="category_id" ref="module_category_fastapi" />
     </record>
 </odoo>

--- a/fastapi/tests/common.py
+++ b/fastapi/tests/common.py
@@ -14,8 +14,8 @@ from odoo.api import Environment
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
-from odoo.addons.base.models.res_partner import Partner
-from odoo.addons.base.models.res_users import Users
+from odoo.addons.base.models.res_partner import ResPartner
+from odoo.addons.base.models.res_users import ResUsers
 
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
@@ -80,8 +80,8 @@ class FastAPITransactionCase(TransactionCase):
         cls.default_fastapi_app: FastAPI | None = None
         cls.default_fastapi_router: APIRouter | None = None
         cls.default_fastapi_odoo_env: Environment = cls.env
-        cls.default_fastapi_running_user: Users | None = None
-        cls.default_fastapi_authenticated_partner: Partner | None = None
+        cls.default_fastapi_running_user: ResUsers | None = None
+        cls.default_fastapi_authenticated_partner: ResPartner | None = None
         cls.default_fastapi_dependency_overrides: dict[
             Callable[..., Any], Callable[..., Any]
         ] = {}
@@ -91,8 +91,8 @@ class FastAPITransactionCase(TransactionCase):
         self,
         app: FastAPI | None = None,
         router: APIRouter | None = None,
-        user: Users | None = None,
-        partner: Partner | None = None,
+        user: ResUsers | None = None,
+        partner: ResPartner | None = None,
         env: Environment = None,
         dependency_overrides: dict[Callable[..., Any], Callable[..., Any]] = None,
         raise_server_exceptions: bool = True,

--- a/fastapi/views/fastapi_endpoint.xml
+++ b/fastapi/views/fastapi_endpoint.xml
@@ -72,13 +72,11 @@
                     name="inactive"
                     domain="[('active','=',False)]"
                 />
-                <group expand='0' string='Group by...'>
-                    <filter
-                        string='App'
-                        name="groupby_app"
-                        context="{'group_by': 'app'}"
-                    />
-                </group>
+                <filter
+                    string='App'
+                    name="groupby_app"
+                    context="{'group_by': 'app'}"
+                />
             </search>
         </field>
     </record>

--- a/fastapi/views/fastapi_menu.xml
+++ b/fastapi/views/fastapi_menu.xml
@@ -6,6 +6,6 @@
         <field name="name">FastAPI</field>
         <field name="sequence" eval="400" />
         <field name="web_icon">fastapi,static/description/icon.png</field>
-        <field name="groups_id" eval="[(4, ref('group_fastapi_user'))]" />
+        <field name="group_ids" eval="[(4, ref('group_fastapi_user'))]" />
     </record>
 </odoo>


### PR DESCRIPTION
The latest odoo19 branch has introduced breaking changes for the module "fastapi"

This pull request makes the module installable on odoo19.

Key fixes : 

- Updated __manifest__.py to make the project installable and also bumped the base version to 19

- Odoo19 has changed the python class names for Partner and Users to ResPartner and ResUsers and fastapi module imported them directly, The import names have been fixed accordingly

- Odoo19 has changed the field name for users in "res.groups" from "users" to "user_ids" therefore res_groups.xml files has been patched with these changes

- Odoo19 removed the field "category_id" from the model "res.groups" for some reason, Therefore I have removed the field in res_groups.xml

- Odoo19 also changed the groups field name for the model "ir.ui.menu" to group_ids, So I have fixed that in fastapi_menu.xml

- Odoo19 search view definition doesn't allow the tag <group> anymore so I have removed it, Keeping only the "App" filter.

After testing the commit, The expected result is that the "fastapi" module can be installed on an odoo19 database.