### PR TITLE
[18.0] [FIX] fastapi: support both starlette < and >= 0.48

### DIFF
--- a/fastapi/error_handlers.py
+++ b/fastapi/error_handlers.py
@@ -29,7 +29,10 @@ def convert_exception_to_status_body(exc: Exception) -> tuple[int, dict]:
         status_code = exc.status_code
         details = exc.detail
     elif isinstance(exc, RequestValidationError):
-        status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
+        # Use integer status code to supress starlette >= 0.48 deprecation warning
+        # See: https://github.com/fastapi/fastapi/pull/14077
+        # status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
+        status_code = 422
         details = jsonable_encoder(exc.errors())
     elif isinstance(exc, WebSocketRequestValidationError):
         status_code = status.WS_1008_POLICY_VIOLATION

--- a/fastapi/tests/test_fastapi.py
+++ b/fastapi/tests/test_fastapi.py
@@ -156,9 +156,7 @@ class FastAPIHttpCase(HttpCase):
             route = "/fastapi_demo/demo/exception?exception_type=BAD&error_message="
             response = self.url_open(route, timeout=200)
             mocked_commit.assert_not_called()
-            self.assertEqual(
-                response.status_code, status.HTTP_422_UNPROCESSABLE_CONTENT
-            )
+            self.assertEqual(response.status_code, 422)
 
     def test_no_commit_on_exception(self) -> None:
         # this test check that the way we mock the cursor is working as expected


### PR DESCRIPTION
Recent merged changes in a5bae2ba changed `status.HTTP_422_UNPROCESSABLE_ENTITY` to `status.HTTP_422_UNPROCESSABLE_CONTENT` in order to supress a deprecation warning emitted by the `starlette >= 0.48` library.

However, older versions of `starlette` will simply break with this change.

```
Module 'starlette.status' has no attribute 'HTTP_422_UNPROCESSABLE_CONTENT'.
Did you mean: 'HTTP_422_UNPROCESSABLE_ENTITY'?
```

~For this reason, we bump the minimum required version of `fastapi` to 0.120.0, which consumes newer versions of `starlette` where this is not an issue.~

To be compatible with past and future versions, we simply use the integer value `422`, aligning also with the updated `fastapi` documentation:

See:
- https://github.com/fastapi/fastapi/pull/14077