### PR TITLE
[18.0] [IMP] fastapi: show message for AccessError | MissingError

### DIFF
--- a/fastapi/error_handlers.py
+++ b/fastapi/error_handlers.py
@@ -36,10 +36,10 @@ def convert_exception_to_status_body(exc: Exception) -> tuple[int, dict]:
         details = jsonable_encoder(exc.errors())
     elif isinstance(exc, AccessDenied | AccessError):
         status_code = status.HTTP_403_FORBIDDEN
-        details = "AccessError"
+        details = exc.args[0]
     elif isinstance(exc, MissingError):
         status_code = status.HTTP_404_NOT_FOUND
-        details = "MissingError"
+        details = exc.args[0]
     elif isinstance(exc, UserError):
         status_code = status.HTTP_400_BAD_REQUEST
         details = exc.args[0]

--- a/fastapi/tests/test_fastapi.py
+++ b/fastapi/tests/test_fastapi.py
@@ -130,7 +130,7 @@ class FastAPIHttpCase(HttpCase):
         self.assert_exception_processed(
             exception_type=DemoExceptionType.access_error,
             error_message="test",
-            expected_message="AccessError",
+            expected_message="test",
             expected_status_code=status.HTTP_403_FORBIDDEN,
         )
 
@@ -138,7 +138,7 @@ class FastAPIHttpCase(HttpCase):
         self.assert_exception_processed(
             exception_type=DemoExceptionType.missing_error,
             error_message="test",
-            expected_message="MissingError",
+            expected_message="test",
             expected_status_code=status.HTTP_404_NOT_FOUND,
         )
 


### PR DESCRIPTION
It's common to raise, for example, `MissingError` when a related record is not found in a CREATE/WRITE operation.

e.g.: let's say the endpoint allows to create partner, providing the `country_code` to reference a valid country. If there's no country record with such country_code, we want to raise a MissingError with a meaningful message for the api consumer (e.g.: "No country found with code: %s")