### PR TITLE
[18.0] [FIX] fastapi: Change circular import fix to avoid crash with fastapi>=0.123.7

### DIFF
--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -1,7 +1,7 @@
 # Copyright 2022 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
 
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 from odoo.api import Environment
 from odoo.exceptions import AccessDenied
@@ -13,10 +13,8 @@ from fastapi import Depends, Header, HTTPException, Query, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 from .context import odoo_env_ctx
+from .models.fastapi_endpoint import FastapiEndpoint
 from .schemas import Paging
-
-if TYPE_CHECKING:
-    from .models.fastapi_endpoint import FastapiEndpoint
 
 
 def company_id() -> int | None:

--- a/fastapi/models/fastapi_endpoint.py
+++ b/fastapi/models/fastapi_endpoint.py
@@ -14,7 +14,6 @@ from odoo import _, api, exceptions, fields, models, tools
 
 from fastapi import APIRouter, Depends, FastAPI
 
-from .. import dependencies
 from ..middleware import ASGIMiddleware
 
 _logger = logging.getLogger(__name__)
@@ -310,9 +309,12 @@ class FastapiEndpoint(models.Model):
         return app
 
     def _get_app_dependencies_overrides(self) -> dict[Callable, Callable]:
+        # Import here to avoid circular import while waiting for lazy imports
+        from ..dependencies import company_id, fastapi_endpoint_id
+
         return {
-            dependencies.fastapi_endpoint_id: partial(lambda a: a, self.id),
-            dependencies.company_id: partial(lambda a: a, self.company_id.id),
+            fastapi_endpoint_id: partial(lambda a: a, self.id),
+            company_id: partial(lambda a: a, self.company_id.id),
         }
 
     def _prepare_fastapi_app_params(self) -> dict[str, Any]:
@@ -337,4 +339,7 @@ class FastapiEndpoint(models.Model):
 
     def _get_fastapi_app_dependencies(self) -> list[Depends]:
         """Return the dependencies to use for the fastapi app."""
-        return [Depends(dependencies.accept_language)]
+        # Import here to avoid circular import too
+        from ..dependencies import accept_language
+
+        return [Depends(accept_language)]


### PR DESCRIPTION
Since fastapi 0.123.7, due to https://github.com/fastapi/fastapi/pull/11355 the fastapi odoo module crash at start with:
```
  File "/odoo/links/fastapi/routers/demo_router.py", line 81, in <module>
    @router.get(
     ^^^^^^^^^^^
  File "/odoo/lib/python3.12/site-packages/fastapi/routing.py", line 1072, in decorator
    self.add_api_route(
  File "/odoo/lib/python3.12/site-packages/fastapi/routing.py", line 1011, in add_api_route
    route = route_class(
            ^^^^^^^^^^^^
  File "/odoo/lib/python3.12/site-packages/fastapi/routing.py", line 630, in __init__
    self.dependant = get_dependant(
                     ^^^^^^^^^^^^^^
  File "/odoo/lib/python3.12/site-packages/fastapi/dependencies/utils.py", line 290, in get_dependant
    sub_dependant = get_dependant(
                    ^^^^^^^^^^^^^^
  File "/odoo/lib/python3.12/site-packages/fastapi/dependencies/utils.py", line 259, in get_dependant
    endpoint_signature = get_typed_signature(call)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/lib/python3.12/site-packages/fastapi/dependencies/utils.py", line 196, in get_typed_signature
    signature = inspect.signature(call, eval_str=True)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 3310, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 3054, in from_callable
    return _signature_from_callable(obj, sigcls=cls,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 2566, in _signature_from_callable
    return _signature_from_function(sigcls, obj,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 2393, in _signature_from_function
    annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 285, in get_annotations
    value if not isinstance(value, str) else eval(value, globals, locals)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
NameError: name 'FastapiEndpoint' is not defined. Did you mean: 'fastapi_endpoint'?
```

This PR removes the TYPE_CHECKING import condition and solves the circular import by delaying the other side import instead.

Backport to 16.0 in https://github.com/akretion/rest-framework/tree/16.0-fix-fastapi-TYPE_CHECKING-crash