### PR TITLE
Fxing circular imports causing 'FastapiEndpoint' not recognized

### DIFF
--- a/fastapi/models/fastapi_endpoint_demo.py
+++ b/fastapi/models/fastapi_endpoint_demo.py
@@ -11,12 +11,17 @@ from odoo.addons.base.models.res_partner import Partner
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import APIKeyHeader
 
+
 from ..dependencies import (
     authenticated_partner_from_basic_auth_user,
     authenticated_partner_impl,
     odoo_env,
 )
-from ..routers import demo_router, demo_router_doc
+
+# Add imports for TYPE_CHECKING
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ..routers import demo_router, demo_router_doc
 
 
 class FastapiEndpoint(models.Model):
@@ -32,6 +37,8 @@ class FastapiEndpoint(models.Model):
 
     def _get_fastapi_routers(self) -> list[APIRouter]:
         if self.app == "demo":
+            # Import here to avoid circular import
+            from ..routers import demo_router
             return [demo_router]
         return super()._get_fastapi_routers()
 
@@ -73,6 +80,8 @@ class FastapiEndpoint(models.Model):
     def _prepare_fastapi_app_params(self) -> dict[str, Any]:
         params = super()._prepare_fastapi_app_params()
         if self.app == "demo":
+            # Import here to avoid circular import
+            from ..routers import demo_router_doc
             tags_metadata = params.get("openapi_tags", []) or []
             tags_metadata.append({"name": "demo", "description": demo_router_doc})
             params["openapi_tags"] = tags_metadata

--- a/fastapi/routers/demo_router.py
+++ b/fastapi/routers/demo_router.py
@@ -83,7 +83,7 @@ async def who_ami(
     dependencies=[Depends(authenticated_partner)],
 )
 async def endpoint_app_info(
-    endpoint: Annotated[FastapiEndpoint, Depends(fastapi_endpoint)],
+    endpoint: Annotated["FastapiEndpoint", Depends(fastapi_endpoint)],
 ) -> DemoEndpointAppInfo:
     """Returns the current endpoint configuration"""
     # This method show you how to get access to current endpoint configuration


### PR DESCRIPTION
When trying to install `fastapi` module we get this error:

`2025-12-06 19:16:30,375 306 CRITICAL odoo odoo.modules.module: Couldn't load module fastapi 
2025-12-06 19:16:30,379 306 WARNING odoo odoo.modules.loading: Transient module states were reset 
2025-12-06 19:16:30,381 306 ERROR odoo odoo.modules.registry: Failed to load registry 
2025-12-06 19:16:30,381 306 CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`. 
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/service/server.py", line 1366, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/decorator.py", line 235, in fun
    return caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/modules/registry.py", line 129, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(env, graph,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
                        ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 186, in load_module_graph
    load_openerp_module(package.name)
  File "/usr/lib/python3/dist-packages/odoo/modules/module.py", line 384, in load_openerp_module
    __import__(qualname)
  File "/mnt/oca-rest-framework/fastapi/__init__.py", line 1, in <module>
    from . import models
  File "/mnt/oca-rest-framework/fastapi/models/__init__.py", line 2, in <module>
    from . import fastapi_endpoint_demo
  File "/mnt/oca-rest-framework/fastapi/models/fastapi_endpoint_demo.py", line 19, in <module>
    from ..routers import demo_router, demo_router_doc
  File "/mnt/oca-rest-framework/fastapi/routers/__init__.py", line 1, in <module>
    from .demo_router import router as demo_router
  File "/mnt/oca-rest-framework/fastapi/routers/demo_router.py", line 81, in <module>
    @router.get(
     ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 1072, in decorator
    self.add_api_route(
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 1011, in add_api_route
    route = route_class(
            ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 630, in __init__
    self.dependant = get_dependant(
                     ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/dependencies/utils.py", line 303, in get_dependant
    sub_dependant = get_dependant(
                    ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/dependencies/utils.py", line 277, in get_dependant
    endpoint_signature = get_typed_signature(call)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/dependencies/utils.py", line 214, in get_typed_signature
    signature = inspect.signature(call, eval_str=True)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 3310, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 3054, in from_callable
    return _signature_from_callable(obj, sigcls=cls,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 2566, in _signature_from_callable
    return _signature_from_function(sigcls, obj,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 2393, in _signature_from_function
    annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 285, in get_annotations
    value if not isinstance(value, str) else eval(value, globals, locals)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
NameError: name 'FastapiEndpoint' is not defined. Did you mean: 'fastapi_endpoint'?
`
