### PR TITLE
[16.0] [BACKPORT] [FIX] fastapi: Change circular import fix to avoid crash with fastapi>=0.123.7

### DIFF
--- a/fastapi/dependencies.py
+++ b/fastapi/dependencies.py
@@ -1,7 +1,7 @@
 # Copyright 2022 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
 
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 from odoo.api import Environment
 from odoo.exceptions import AccessDenied
@@ -13,10 +13,8 @@ from fastapi import Depends, Header, HTTPException, Query, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 from .context import odoo_env_ctx
+from .models.fastapi_endpoint import FastapiEndpoint
 from .schemas import Paging
-
-if TYPE_CHECKING:
-    from .models.fastapi_endpoint import FastapiEndpoint
 
 
 def company_id() -> int | None:

--- a/fastapi/models/fastapi_endpoint.py
+++ b/fastapi/models/fastapi_endpoint.py
@@ -13,7 +13,6 @@ from odoo import _, api, exceptions, fields, models, tools
 
 from fastapi import APIRouter, Depends, FastAPI
 
-from .. import dependencies
 from ..middleware import ASGIMiddleware
 
 _logger = logging.getLogger(__name__)
@@ -316,9 +315,12 @@ class FastapiEndpoint(models.Model):
         return app
 
     def _get_app_dependencies_overrides(self) -> Dict[Callable, Callable]:
+        # Import here to avoid circular import while waiting for lazy imports
+        from ..dependencies import company_id, fastapi_endpoint_id
+
         return {
-            dependencies.fastapi_endpoint_id: partial(lambda a: a, self.id),
-            dependencies.company_id: partial(lambda a: a, self.company_id.id),
+            fastapi_endpoint_id: partial(lambda a: a, self.id),
+            company_id: partial(lambda a: a, self.company_id.id),
         }
 
     def _prepare_fastapi_app_params(self) -> Dict[str, Any]:
@@ -343,4 +345,7 @@ class FastapiEndpoint(models.Model):
 
     def _get_fastapi_app_dependencies(self) -> List[Depends]:
         """Return the dependencies to use for the fastapi app."""
-        return [Depends(dependencies.accept_language)]
+        # Import here to avoid circular import too
+        from ..dependencies import accept_language
+
+        return [Depends(accept_language)]


### PR DESCRIPTION
Backport of #574