### PR TITLE
[14.0][FIX] add datetime.time to JSONEncoder

### DIFF
--- a/base_rest/http.py
+++ b/base_rest/http.py
@@ -50,6 +50,8 @@ class JSONEncoder(json.JSONEncoder):
             return obj.isoformat()
         elif isinstance(obj, datetime.date):
             return obj.isoformat()
+        elif isinstance(obj, datetime.time):
+            return obj.isoformat()
         elif isinstance(obj, decimal.Decimal):
             return float(obj)
         return super(JSONEncoder, self).default(obj)


### PR DESCRIPTION
`Time` fields can be encoded as `time`, but as other types from `datetime`, need to be converted to str with `isoformat()`