### PR TITLE
[FWD][18.0] base_rest: turn off deprecation logging on demand

### DIFF
--- a/.oca/oca-port/blacklist/base_rest.json
+++ b/.oca/oca-port/blacklist/base_rest.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "https://github.com/OCA/rest-framework/pull/336": "Nothing to port from PR #https://github.com/OCA/rest-framework/pull/336"
+  }
+}

--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -3,6 +3,7 @@
 
 
 import logging
+import os
 
 from werkzeug.exceptions import NotFound
 
@@ -15,6 +16,23 @@ from ..apispec.base_rest_service_apispec import BaseRestServiceAPISpec
 from ..tools import ROUTING_DECORATOR_ATTR
 
 _logger = logging.getLogger(__name__)
+
+
+# Disable logging for deprecation.
+# You might have big projects, with tons of services with no specific decorator,
+# that are well tested and very stable and you don't want to touch them.
+# Especially if you plan already to move to v16.
+# Since this logging can bloat your CI and your log collecting tools,
+# here is a way to prevent that and get only a msg at boot.
+DISABLE_DEPRECATE_LOG_KEY = "REST_API_METHOD_FIX_DECORATOR_DEPRECATE_LOG_DISABLE"
+DISABLE_DEPRECATE_LOG = os.getenv(DISABLE_DEPRECATE_LOG_KEY)
+if DISABLE_DEPRECATE_LOG:
+    msg = (
+        "%s enabled: "
+        "implicit service methods are deprecated. "
+        "Disable this env key and enable debug level to have more details."
+    )
+    _logger.warning(msg, DISABLE_DEPRECATE_LOG_KEY)
 
 
 def to_int(val):
@@ -127,7 +145,7 @@ class BaseRestService(AbstractComponent):
             return result
         routing = getattr(method, ROUTING_DECORATOR_ATTR, None)
         output_param = routing["output_param"]
-        if not output_param:
+        if not output_param and not DISABLE_DEPRECATE_LOG:
             _logger.warning(
                 "DEPRECATED: You must define an output schema for method %s "
                 "in service %s",

--- a/base_rest/components/service.py
+++ b/base_rest/components/service.py
@@ -145,15 +145,16 @@ class BaseRestService(AbstractComponent):
             return result
         routing = getattr(method, ROUTING_DECORATOR_ATTR, None)
         output_param = routing["output_param"]
-        if not output_param and not DISABLE_DEPRECATE_LOG:
+        if output_param:
+            return output_param.to_response(self, result)
+        elif not output_param and not DISABLE_DEPRECATE_LOG:
             _logger.warning(
                 "DEPRECATED: You must define an output schema for method %s "
                 "in service %s",
                 method_name,
                 self._name,
             )
-            return result
-        return output_param.to_response(self, result)
+        return result
 
     def dispatch(self, method_name, *args, params=None):
         """


### PR DESCRIPTION
Disable logging for deprecation.
You might have big projects, with tons of services with no specific decorator,
that are well tested and very stable and you don't want to touch them.
Especially if you plan already to move to v16.
Since this logging can bloat your CI and your log collecting tools,
here is a way to prevent that and get only a msg at boot.

Once enabled, you'll see this msg in the logs only at start up:

'odoo.addons.base_rest.components.service: REST_API_METHOD_FIX_DECORATOR_DEPRECATE_LOG_DISABLE enabled: implicit service methods are deprecated. Disable this env key and enable debug level to have more details.'


Manual FWD port of https://github.com/OCA/rest-framework/pull/336 as it was fully incompatible. 