### PR TITLE
[19.0][IMP] fastapi: parse db param in sessionless requests

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,3 +1,4 @@
 from . import models
 from . import fastapi_dispatcher
 from . import error_handlers
+from . import patch

--- a/fastapi/patch.py
+++ b/fastapi/patch.py
@@ -1,0 +1,31 @@
+# Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
+
+from urllib.parse import parse_qs, urlparse
+
+from odoo.http import Request, db_filter
+
+_original_get_session_and_dbname = Request._get_session_and_dbname
+
+
+def _patched_get_session_and_dbname(self):
+    session, dbname = _original_get_session_and_dbname(self)
+    if not dbname:
+        # Try to get the database from request "db" param.
+        # This is useful for multi-database environments.
+        db = self.httprequest.args.get("db", "").strip()
+        if not db:
+            # For browser sub-requests (e.g. openapi.json or static assets fetched
+            # by Swagger UI / ReDoc), the browser sets a Referer header pointing
+            # to the docs page which may carry the "db" query parameter.
+            referer = self.httprequest.headers.get("Referer", "")
+            if referer:
+                parsed = urlparse(referer)
+                db = parse_qs(parsed.query).get("db", [""])[0].strip()
+        if db and db_filter([db]):
+            dbname = db
+            session.db = dbname
+    return session, dbname
+
+
+Request._get_session_and_dbname = _patched_get_session_and_dbname

--- a/fastapi/readme/CONTRIBUTORS.md
+++ b/fastapi/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Laurent Mignon \<<laurent.mignon@acsone.eu>\>
+- Lois Rilo \<<lois.rilo@forgeflow.com>\>

--- a/fastapi/tests/__init__.py
+++ b/fastapi/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_fastapi
 from . import test_fastapi_demo
+from . import test_db_param

--- a/fastapi/tests/test_db_param.py
+++ b/fastapi/tests/test_db_param.py
@@ -1,0 +1,83 @@
+# Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
+
+from unittest.mock import MagicMock, patch
+
+from odoo.http import Request
+from odoo.tests.common import TransactionCase
+
+
+class TestPatchGetSessionAndDbname(TransactionCase):
+    """Tests for the _patched_get_session_and_dbname patch.
+
+    The patch extends Request._get_session_and_dbname to resolve the database
+    from a ?db= query parameter or a Referer header when Odoo's normal session
+    mechanism cannot determine the database (e.g. multi-database staging setups).
+    """
+
+    def _make_request(self, db_param="", referer=""):
+        mock_request = MagicMock()
+        mock_request.httprequest.args = {"db": db_param} if db_param else {}
+        mock_request.httprequest.headers = {"Referer": referer} if referer else {}
+        return mock_request
+
+    def _call_patched(self, mock_request, original_return, db_filter_return):
+        with (
+            patch(
+                "odoo.addons.fastapi.patch._original_get_session_and_dbname",
+                return_value=original_return,
+            ),
+            patch(
+                "odoo.addons.fastapi.patch.db_filter",
+                return_value=db_filter_return,
+            ),
+        ):
+            return Request._get_session_and_dbname(mock_request)
+
+    def test_db_already_resolved(self):
+        """When the original method resolves a dbname, the patch must not interfere."""
+        session = MagicMock()
+        result_session, result_db = self._call_patched(
+            self._make_request(),
+            original_return=(session, "existing_db"),
+            db_filter_return=["existing_db"],
+        )
+        self.assertEqual(result_db, "existing_db")
+        self.assertEqual(result_session, session)
+
+    def test_db_from_query_param(self):
+        """When dbname is absent, resolve it from the ?db= query parameter."""
+        session = MagicMock()
+        result_session, result_db = self._call_patched(
+            self._make_request(db_param="mydb"),
+            original_return=(session, None),
+            db_filter_return=["mydb"],
+        )
+        self.assertEqual(result_db, "mydb")
+        self.assertEqual(session.db, "mydb")
+
+    def test_db_from_referer_header(self):
+        """When ?db= is absent, fall back to the db param in the Referer header.
+
+        This covers browser sub-requests (e.g. openapi.json, Swagger UI assets)
+        where the Referer points to the docs page carrying ?db=.
+        """
+        session = MagicMock()
+        result_session, result_db = self._call_patched(
+            self._make_request(referer="https://example.com/docs?db=mydb"),
+            original_return=(session, None),
+            db_filter_return=["mydb"],
+        )
+        self.assertEqual(result_db, "mydb")
+        self.assertEqual(session.db, "mydb")
+
+    def test_db_rejected_by_filter(self):
+        """A db name that fails db_filter must not be used."""
+        session = MagicMock()
+        result_session, result_db = self._call_patched(
+            self._make_request(db_param="forbidden_db"),
+            original_return=(session, None),
+            db_filter_return=[],
+        )
+        self.assertIsNone(result_db)
+        self.assertFalse(hasattr(session, "db") and session.db == "forbidden_db")


### PR DESCRIPTION
It is useful for multi-database environments.

Fwport of https://github.com/OCA/rest-framework/pull/607