### PR TITLE
[PERF] api_log_mail: Faster attachment deletion

### DIFF
--- a/api_log_mail/models/api_log.py
+++ b/api_log_mail/models/api_log.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Simone Rubino - PyTech
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class APILog(models.Model):
@@ -15,6 +15,8 @@ class APILog(models.Model):
         "mail.thread",
     ]
     _mail_post_access = "read"  # Access required to open an activity
+
+    message_main_attachment_id = fields.Many2one(index="btree_not_null")
 
     @api.model
     def log_request(self, request, override_log_values=None):


### PR DESCRIPTION
When deleting an `ir.attachment`, all the foreing keys are inspected: if the `api.log` has a lot of records this could be very slow.

In our instance there are 2 million records and deleting a record takes ~500ms, after this change the same deletion takes less than 1ms.

Note that this change is not needed in future versions because in `17.0` the main attachment is moved to the dedicated mixin `mail.thread.main.attachment` (see https://github.com/odoo/odoo/commit/f8c7f2e5bb2495a0a7d68a15033a94a90f51dd9b).