### PR TITLE
[19.0][FIX] test-requirements: use httpx2 for starlette TestClient

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 odoo_test_helper
-httpx
+httpx2


### PR DESCRIPTION
On 19.0, `test-requirements.txt` pins `httpx`, but starlette's `TestClient` in this stack imports `httpx2` (`import httpx2 as httpx`). Without `httpx2` installed, the TestClient falls back to `httpx` and emits a `StarletteDeprecationWarning`, which the OCA CI log check treats as an error — failing `test with Odoo` / `test with OCB` for `fastapi` and every module depending on it (e.g. #619).

The 18.0 branch already uses `httpx2` here; the change didn't carry over when 19.0 diverged. This restores it, unblocking the test CI for fastapi-dependent modules on 19.0.
