### PR TITLE
[16.0][IMP] base_rest: Remove deprecation warning from the logs

### DIFF
--- a/base_rest/__init__.py
+++ b/base_rest/__init__.py
@@ -1,10 +1,3 @@
-import logging
 from . import models
 from . import components
 from . import http
-
-logging.getLogger(__file__).warning(
-    "base_rest is deprecated and not fully supported anymore on Odoo 16. "
-    "Please migrate to the FastAPI migration module. "
-    "See https://github.com/OCA/rest-framework/pull/291.",
-)

--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,0 +1,3 @@
+[checklog-odoo]
+ignore=
+    WARNING.* 0 failed, 0 error\(s\).*


### PR DESCRIPTION
Backport from 18.0