### PR TITLE
[18.0][FIX] fastapi_log: skip logging when not installed on the request DB

### DIFF
--- a/fastapi_log/fastapi_dispatcher.py
+++ b/fastapi_log/fastapi_dispatcher.py
@@ -51,7 +51,10 @@ class FastApiDispatcher(_dispatchers.get("fastapi", BaseFastApiDispatcher)):
             .sudo()
             ._get_endpoint(environ["PATH_INFO"])
         )
-        if fastapi_endpoint.log_requests:
+        # This dispatcher is registered process-wide, so it is also used for
+        # databases where fastapi_log is not installed. In that case the
+        # `log_requests` field is not part of the registry, so skip logging.
+        if "log_requests" in fastapi_endpoint._fields and fastapi_endpoint.log_requests:
             with self._create_log_env(self.request.env) as log_env:
                 try:
                     log = log_env["api.log"].log_request(self.request)


### PR DESCRIPTION
## Bug

`fastapi_log` registers its own `FastApiDispatcher` through `odoo.http._dispatchers` by subclassing the fastapi dispatcher with `routing_type = "fastapi"`. That registration is **process-wide** and happens as soon as the module is imported, so once `fastapi_log` is loaded for a single database its dispatcher handles the fastapi routing of **every** database served by the same worker process.

The dispatcher reads `fastapi_endpoint.log_requests`, a field this module adds to `fastapi.endpoint` through `api.log_collection.mixin`. On a database where `fastapi_log` is **not** installed that field does not exist, so the access raised an `AttributeError` and broke every fastapi endpoint of that database.

## How to reproduce

Two databases in the same instance:

- **DB A** — `fastapi_log` installed
- **DB B** — only `fastapi` installed (no `fastapi_log`)

As soon as DB A is loaded, its dispatcher is registered process-wide. Any subsequent request to a fastapi endpoint of **DB B** then crashes with a 500 (`AttributeError` on `log_requests`), even though DB B never installed `fastapi_log`.

## Fix

Guard the field access with `"log_requests" in fastapi_endpoint._fields` so logging only happens when the module is actually installed on the request's database; otherwise fall back to the base dispatch.

