### PR TITLE
[IMP] fastapi: As we have route_group, we could use it

### DIFF
--- a/fastapi/models/fastapi_endpoint.py
+++ b/fastapi/models/fastapi_endpoint.py
@@ -65,6 +65,7 @@ class FastapiEndpoint(models.Model):
         "unexpecteed disk space consumption.",
         default=True,
     )
+    route_group = fields.Char(help="Use this to classify routes together", size=32)
 
     @api.depends("root_path")
     def _compute_root_path(self):
@@ -124,7 +125,7 @@ class FastapiEndpoint(models.Model):
     def _routing_impacting_fields(self) -> tuple[str, ...]:
         """The list of fields requiring to refresh the mount point of the pp
         into odoo if modified"""
-        return ("root_path", "save_http_session")
+        return ("root_path", "save_http_session", "route_group")
 
     #
     # end of endpoint.route.sync.mixin methods implementation
@@ -161,7 +162,7 @@ class FastapiEndpoint(models.Model):
         key = self._endpoint_registry_route_unique_key(routing)
         endpoint_hash = hash(route)
         return self._endpoint_registry.make_rule(
-            key, route, options, routing, endpoint_hash
+            key, route, options, routing, endpoint_hash, route_group=self.route_group
         )
 
     def _default_endpoint_options(self):

--- a/fastapi/views/fastapi_endpoint.xml
+++ b/fastapi/views/fastapi_endpoint.xml
@@ -42,6 +42,7 @@
                     <group>
                         <group>
                             <field name="app" />
+                            <field name="route_group" />
                             <field name="root_path" />
                             <field name="user_id" />
                             <field name="company_id" />


### PR DESCRIPTION
This allows us to set the route_group.

Really interesting in conjunction with https://github.com/OCA/web-api/pull/149