### PR TITLE
[19.0][FIX] test-requirements: pin anyio<4.15 to unblock CI

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,5 @@
 odoo_test_helper
 httpx2
+# starlette.testclient still uses the anyio.abc.BlockingPortal alias, which
+# anyio 4.15 deprecates: the resulting DeprecationWarning fails checklog-odoo.
+anyio<4.15


### PR DESCRIPTION
## Problem

`checklog-odoo` (`OCA_ENABLE_CHECKLOG_ODOO: "1"`) treats this record as an
error, failing the job after the addon tests have completed:

```
WARNING odoo py.warnings: starlette/testclient.py:53: DeprecationWarning:
The anyio.abc.BlockingPortal alias is deprecated, use anyio.from_thread.BlockingPortal instead.
```

This causes a red CI on every PR targeting `19.0` (like my PR here: #616)
## Root cause

anyio 4.15.0, released after the last run on `19.0`, turned
`anyio.abc.BlockingPortal` into a deprecated alias. `_PortalFactoryType` in
`starlette/testclient.py` is evaluated at import time, so merely importing
`starlette.testclient` emits the warning.

Timeline, since the branches still show green:

- anyio 4.15.0 published to PyPI: Sep 2
- last run on `19.0`: Aug 11
- last run on `18.0`: Sep 1

This is tracked upstream in Kludex/starlette#3497, with a fix proposed in
Kludex/starlette#3506 (opened Sep 4, not yet merged).
starlette 1.6.0 (latest) still ships the old alias, so no released version
avoids this today.

## Fix

Pin `anyio<4.15` in `test-requirements.txt`. This only constrains the test
environment. It can be dropped once a starlette **release** including
Kludex/starlette#3506 is available, not merely once that PR is merged.

CI on this PR is the verification: same code as `19.0`, green with the pin.

## Scope

Problably this problem affects every PR on this repo, not just the one where I hit it (#616).
`16.0`, `17.0` and `18.0` have the same import and need the same change; I can
open the equivalent PRs on those branches on request.