### PR TITLE
[19.0][FIX] CI: Ignore DeprecationWarning issued by anyio>=4.15

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,5 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    # from anyio>=4.15 see https://github.com/Kludex/starlette/issues/3497
+    WARNING.* DeprecationWarning: The anyio.abc.BlockingPortal alias is deprecated.*


### PR DESCRIPTION
An alternative to #636 